### PR TITLE
Preserve responsive PNG image format

### DIFF
--- a/data/srcsets.yml
+++ b/data/srcsets.yml
@@ -29,6 +29,7 @@ entry:
     - avif
     - webp
     - jpg
+    - png
 full:
   sizes:
     - "(min-width: 1280px) 1008px"
@@ -60,6 +61,7 @@ full:
     - avif
     - webp
     - jpg
+    - png
 avatar:
   sizes:
     - "(min-width: 1280px) 72px"
@@ -76,6 +78,7 @@ avatar:
     - avif
     - webp
     - jpg
+    - png
 home:
   sizes:
     - "(min-width: 1280px) 488px"
@@ -98,3 +101,4 @@ home:
     - avif
     - webp
     - jpg
+    - png

--- a/lib/helpers/markup_helpers.rb
+++ b/lib/helpers/markup_helpers.rb
@@ -311,12 +311,19 @@ module MarkupHelpers
       # Skip to the next image if it's a gif.
       next if content_type == 'image/gif'
 
+      # PNG images should remain as PNGs, not be converted to other formats
+      image_formats = if content_type == 'image/png'
+        ['png']
+      else
+        formats
+      end
+
       # Then wrap it in a picture element.
       img.wrap('<picture></picture>')
 
       # Add a source element for each image format,
       # as a sibling of the img element in the picture tag.
-      formats.each do |format|
+      image_formats.each do |format|
         img.add_previous_sibling(source_tag(original_url, sizes: sizes, type: "image/#{format}", format: format, widths: img_widths, square: square))
       end
     end


### PR DESCRIPTION
Preserve responsive PNG images as PNGs by preventing their conversion to other formats.