### PR TITLE
Update wind direction icon

### DIFF
--- a/data/font_awesome.yml
+++ b/data/font_awesome.yml
@@ -111,7 +111,7 @@ icons:
       - leaf
       - fire-smoke
       - smoke
-      - arrow-up
+      - arrow-down
     thin:
       - bolt-lightning
       - cloud-bolt

--- a/source/partials/_event_weather.html.erb
+++ b/source/partials/_event_weather.html.erb
@@ -45,7 +45,7 @@
       <div class="event__weather-stat-group">
         <span class="event__weather-stat">
           <span class="event__weather-wind-direction" style="--wind-direction: <%= event.weather.daytime_forecast.wind_direction %>;" title="<%= wind_direction(event.weather.daytime_forecast.wind_direction) %>">
-            <%= icon_svg("classic", "light", "arrow-up") %>
+            <%= icon_svg("classic", "light", "arrow-down") %>
           </span>
           <%= format_wind_speed_range(event.weather.daytime_forecast.wind_speed, event.weather.daytime_forecast.wind_speed_max) %>
           wind

--- a/source/stylesheets/components/_event.scss
+++ b/source/stylesheets/components/_event.scss
@@ -70,5 +70,5 @@
 }
 
 .event__weather-wind-direction svg {
-  transform: rotate(calc((var(--wind-direction) + 180) * 1deg));
+  transform: rotate(calc(var(--wind-direction) * 1deg));
 }


### PR DESCRIPTION
Replace wind direction icon with `arrow-down` and adjust rotation to correctly indicate wind origin.

The `arrow-up` icon was replaced with `arrow-down` in the event weather partial, and the CSS rotation logic was updated from `(var(--wind-direction) + 180)` to `var(--wind-direction)`. This ensures the arrow points in the direction the wind is blowing from, aligning with meteorological conventions. The Font Awesome configuration was also updated to include `arrow-down` and remove the unused `arrow-up`.