### PR TITLE
Only sync Intervals.icu forecast on webhook builds

### DIFF
--- a/lib/data/location.rb
+++ b/lib/data/location.rb
@@ -7,7 +7,16 @@ class Location
 
   # Initializes the Location instance by fetching the current location from available sources.
   def initialize
+    @from_webhook = false
     @latitude, @longitude = split_into_coordinates(current_location)
+  end
+
+  # Whether this build's location was just delivered by a Netlify build hook
+  # payload (as opposed to being read from cache or env). Used to decide
+  # whether to push the location to downstream services like Intervals.icu.
+  # @return [Boolean]
+  def from_webhook?
+    @from_webhook
   end
 
   private
@@ -25,6 +34,7 @@ class Location
     if valid_coordinates?(latitude, longitude)
       location = "#{latitude},#{longitude}"
       $redis.set(LOCATION_CACHE_KEY, location)
+      @from_webhook = true
       location
     else
       $redis.get(LOCATION_CACHE_KEY)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -85,7 +85,9 @@ task :import => [:dotenv, :clobber] do
   # Wait for all threads to complete
   (independent_threads + [sequential_thread]).each(&:join)
 
-  measure_and_output(:update_intervals_weather_config, "Updating Intervals.icu weather config")
+  if @location.from_webhook?
+    measure_and_output(:update_intervals_weather_config, "Updating Intervals.icu weather config")
+  end
 
   total_duration = Time.now - overall_start_time
   puts "\n" + "=" * 60


### PR DESCRIPTION
## Summary

- Track on `Location` whether the current build's coordinates came from a Netlify build hook payload (`from_webhook?`).
- In `rake import`, only call `update_intervals_weather_config` when the location was just delivered by a webhook, instead of every build.

The existing `forecasts_equal?` check inside `Intervals#update_weather_config` still guards against unnecessary writes when the webhook fires with the same coordinates Intervals.icu already has.

## Test plan

- [ ] `bundle exec rake test`
- [ ] `bundle exec rake build:verbose`
- [ ] Trigger a Netlify build hook with a new lat/lon and confirm the Intervals.icu forecast is overwritten.
- [ ] Trigger a normal scheduled build (no `INCOMING_HOOK_BODY`) and confirm the Intervals.icu update step is skipped.

https://claude.ai/code/session_01UjrQQjssLNAXGXNRPQ5n1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjrQQjssLNAXGXNRPQ5n1N)_