### PR TITLE
Bump Redis client timeouts and add reconnect attempts

### DIFF
--- a/lib/data/graphql/font_awesome.rb
+++ b/lib/data/graphql/font_awesome.rb
@@ -13,7 +13,11 @@ module FontAwesomeClient
     host: ENV['REDIS_HOST'] || 'localhost',
     port: ENV['REDIS_PORT'] || 6379,
     username: ENV['REDIS_USERNAME'],
-    password: ENV['REDIS_PASSWORD']
+    password: ENV['REDIS_PASSWORD'],
+    connect_timeout: 5,
+    read_timeout: 3,
+    write_timeout: 3,
+    reconnect_attempts: [0.1, 0.5, 1.0]
   )
 
   def self.get_access_token(api_token)

--- a/lib/helpers/cache_helpers.rb
+++ b/lib/helpers/cache_helpers.rb
@@ -4,7 +4,11 @@ module CacheHelpers
       host: ENV['REDIS_HOST'] || 'localhost',
       port: ENV['REDIS_PORT'] || 6379,
       username: ENV['REDIS_USERNAME'],
-      password: ENV['REDIS_PASSWORD']
+      password: ENV['REDIS_PASSWORD'],
+      connect_timeout: 5,
+      read_timeout: 3,
+      write_timeout: 3,
+      reconnect_attempts: [0.1, 0.5, 1.0]
     )
   end
 end


### PR DESCRIPTION
## Summary

The default 1s `connect_timeout` in the redis-rb client is too aggressive for a Redis hosted across the public internet from Netlify builds — a single cold-connect or TLS handshake spike on the build VM is enough to fail the whole build (as seen in the recent `Connection timed out - user specified timeout for ...:18884: 1.0s` error).

This bumps the timeouts to more forgiving values and adds a small reconnect backoff so transient blips no longer break builds:

- `connect_timeout: 5`
- `read_timeout: 3`
- `write_timeout: 3`
- `reconnect_attempts: [0.1, 0.5, 1.0]`

Applied in both spots that instantiate `$redis` (`lib/helpers/cache_helpers.rb` and `lib/data/graphql/font_awesome.rb`) so they stay in sync.

## Test plan

- [ ] Netlify build completes the data import step without `Redis::CannotConnectError`
- [ ] Local `bundle exec rake test` still passes
- [ ] Local `bundle exec rake build:verbose` still completes

---
_Generated by [Claude Code](https://claude.ai/code/session_018MKYPsGDzRh75uhpAEwXJb)_