### PR TITLE
Set stale-while-revalidate to 1 minute across API endpoints

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -9,7 +9,7 @@ Will sit behind CloudFront.
 - `GET /activity-stats` — returns the monthly activity-stats markup (from Intervals.icu),
   ready to be inserted into the page by the site's `live-update` Stimulus controller.
   Serves permissive CORS (any origin) and caching headers
-  (`Cache-Control: public, max-age=300, stale-while-revalidate=3600`). The upstream
+  (`Cache-Control: public, max-age=300, stale-while-revalidate=60`). The upstream
   Intervals.icu response is cached in Redis for 5 minutes; Font Awesome icon SVGs are
   cached in Redis (per version) as well.
 

--- a/api/app/controllers/api/activity_stats_controller.rb
+++ b/api/app/controllers/api/activity_stats_controller.rb
@@ -6,7 +6,7 @@ module Api
   class ActivityStatsController < ActionController::Base
     def show
       @stats = Intervals.new.stats
-      expires_in 5.minutes, public: true, stale_while_revalidate: 1.hour
+      expires_in 5.minutes, public: true, stale_while_revalidate: 1.minute
 
       if @stats.nil?
         # The live-update controller no-ops on an empty response, leaving the existing markup in place.

--- a/api/app/controllers/api/plausible_controller.rb
+++ b/api/app/controllers/api/plausible_controller.rb
@@ -4,7 +4,7 @@ module Api
   # placeholder and swaps this in. Cached for an hour — view counts change slowly.
   class PlausibleController < ActionController::Base
     def pageviews
-      expires_in 1.hour, public: true, stale_while_revalidate: 1.hour
+      expires_in 1.hour, public: true, stale_while_revalidate: 1.minute
 
       article = Articles.new.find(params[:id])
       return render(plain: "") if article.nil?

--- a/api/app/controllers/api/weather_controller.rb
+++ b/api/app/controllers/api/weather_controller.rb
@@ -9,7 +9,7 @@ module Api
     # renders the summary (or an empty body when weather is unavailable/stale, so the
     # live-update controller leaves the existing markup in place).
     def current
-      expires_in 5.minutes, public: true, stale_while_revalidate: 1.hour
+      expires_in 5.minutes, public: true, stale_while_revalidate: 1.minute
 
       location = Location.new
       return render(plain: "", layout: false) if location.latitude.blank?
@@ -31,7 +31,7 @@ module Api
     end
 
     def event
-      expires_in 1.hour, public: true, stale_while_revalidate: 1.hour
+      expires_in 1.hour, public: true, stale_while_revalidate: 1.minute
 
       record = Events.new.find(params[:id])
       lat = record&.coordinates&.lat

--- a/api/app/controllers/api/whoop_controller.rb
+++ b/api/app/controllers/api/whoop_controller.rb
@@ -6,7 +6,7 @@ module Api
     def show
       @time_zone = resolve_time_zone
       @whoop = Whoop.new.stats
-      expires_in 5.minutes, public: true, stale_while_revalidate: 1.hour
+      expires_in 5.minutes, public: true, stale_while_revalidate: 1.minute
 
       if @whoop.nil?
         # The live-update controller no-ops on an empty response, leaving the existing markup in place.

--- a/api/spec/requests/api/activity_stats_spec.rb
+++ b/api/spec/requests/api/activity_stats_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Activity stats", type: :request do
     cache_control = response.headers["Cache-Control"]
     expect(cache_control).to include("public")
     expect(cache_control).to include("max-age=300")
-    expect(cache_control).to include("stale-while-revalidate=3600")
+    expect(cache_control).to include("stale-while-revalidate=60")
   end
 
   it "allows cross-origin requests from any origin" do

--- a/api/spec/requests/api/weather_current_spec.rb
+++ b/api/spec/requests/api/weather_current_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Weather", type: :request do
     cache_control = response.headers["Cache-Control"]
     expect(cache_control).to include("public")
     expect(cache_control).to include("max-age=300")
-    expect(cache_control).to include("stale-while-revalidate=3600")
+    expect(cache_control).to include("stale-while-revalidate=60")
   end
 
   it "allows cross-origin requests from any origin" do

--- a/api/spec/requests/api/whoop_spec.rb
+++ b/api/spec/requests/api/whoop_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Whoop", type: :request do
     cache_control = response.headers["Cache-Control"]
     expect(cache_control).to include("public")
     expect(cache_control).to include("max-age=300")
-    expect(cache_control).to include("stale-while-revalidate=3600")
+    expect(cache_control).to include("stale-while-revalidate=60")
   end
 
   it "allows cross-origin requests from any origin" do


### PR DESCRIPTION
## Summary

Changes all `stale_while_revalidate` values in the API from `1.hour` to `1.minute`.

### Controllers updated
- `api/app/controllers/api/plausible_controller.rb`
- `api/app/controllers/api/weather_controller.rb` (both `current` and `event` actions)
- `api/app/controllers/api/activity_stats_controller.rb`
- `api/app/controllers/api/whoop_controller.rb`

### Specs updated
Updated `stale-while-revalidate=3600` → `stale-while-revalidate=60` expectations in:
- `api/spec/requests/api/activity_stats_spec.rb`
- `api/spec/requests/api/weather_current_spec.rb`
- `api/spec/requests/api/whoop_spec.rb`

### Docs
- Updated `api/README.md` to reflect the new `stale-while-revalidate=60` value.

https://claude.ai/code/session_01UUzikEu9eLCLNRPQLLdxHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUzikEu9eLCLNRPQLLdxHh)_