### PR TITLE
Redirect API root to main site

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -34,6 +34,6 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  # Redirect the project root to the main site.
+  root to: redirect("https://www.giventotri.com/", status: 301)
 end

--- a/api/spec/requests/root_spec.rb
+++ b/api/spec/requests/root_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "Root", type: :request do
+  describe "GET /" do
+    it "permanently redirects to the main site" do
+      get "/"
+
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.location).to eq("https://www.giventotri.com/")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a root route to the Kona API that permanently redirects requests for the project root (`/`) to https://www.giventotri.com/.

Previously the root route was left commented out (the default Rails scaffold placeholder), so hitting the API root returned a 404. Now it issues a `301 Moved Permanently` redirect to the main site.

## Changes

- `api/config/routes.rb`: replace the commented-out `root` placeholder with `root to: redirect("https://www.giventotri.com/", status: 301)`.
- `api/spec/requests/root_spec.rb`: new request spec asserting `GET /` responds `301` with a `Location` of `https://www.giventotri.com/`.

## Testing

- `rspec spec/requests/root_spec.rb` → passing.
- Note: 3 pre-existing failures in `spec/requests/api/plausible_pageviews_spec.rb` are unrelated to this change (they fail on the base branch as well).

https://claude.ai/code/session_01P52WGkKPyGDPB1jXUKw7r5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P52WGkKPyGDPB1jXUKw7r5)_