### PR TITLE
Don't show the featured event layout without race-day weather

### DIFF
--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -21,6 +21,20 @@ module Api
 
       # On race day the featured event is today's race; give it its own section.
       @todays_race = @featured if @featured && is_today?(@featured)
+
+      # An upcoming (not-today) featured event only earns the expanded treatment when we actually
+      # have race-day weather to show. The featured window (is_close?, in the owner's timezone) and
+      # the weather-fetch window (days_until, computed in the event's own geocoded timezone) can
+      # disagree at the 10-day boundary, which would otherwise leave a featured card carrying an
+      # empty "Race Day Weather" block for an event that's effectively more than 10 days out. When
+      # the weather's missing, demote it to a regular upcoming race (and trim back to the
+      # non-featured count). Today's race keeps its section regardless — it's race day.
+      if @featured && !@todays_race && @event_weather&.forecast.blank?
+        @featured = nil
+        @event_weather = nil
+        @upcoming = @upcoming.take(3)
+      end
+
       @other_races = @upcoming.drop(1) if @todays_race
 
       render :upcoming

--- a/api/app/views/api/events/upcoming.html.erb
+++ b/api/app/views/api/events/upcoming.html.erb
@@ -30,7 +30,7 @@
       </section>
     <% end %>
   <% else %>
-    <section class="collection collection--<%= event_collection_variant %><%= " collection--has-featured" if @featured %>" id="upcoming-races">
+    <section class="collection collection--<%= event_collection_variant(@upcoming.size, featured: @featured.present?) %><%= " collection--has-featured" if @featured %>" id="upcoming-races">
       <h3 class="collection__heading">Upcoming Races</h3>
       <ol class="collection__list">
         <% @upcoming.each do |event| %>

--- a/api/spec/requests/api/events_upcoming_spec.rb
+++ b/api/spec/requests/api/events_upcoming_spec.rb
@@ -140,6 +140,23 @@ RSpec.describe "Api::Events upcoming", type: :request do
     end
   end
 
+  context "when the next race is featured but has no race-day weather" do
+    # The featured window (is_close?, owner timezone) and the weather-fetch window (the event's
+    # own timezone) disagree at the 10-day boundary, so the forecast never gets fetched. The
+    # event must not get the featured layout — no expanded card, no empty "Race Day Weather" block.
+    before { allow_any_instance_of(WeatherKit).to receive(:data).and_return(nil) }
+
+    it "demotes it to a regular upcoming race without the featured layout or weather block" do
+      get "/api/events/upcoming", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Featured Race")
+      expect(response.body).not_to include("collection--has-featured")
+      expect(response.body).not_to include("event--is-featured")
+      expect(response.body).not_to include("Race Day Weather")
+    end
+  end
+
   context "when there are no upcoming races" do
     before { allow_any_instance_of(Events).to receive(:all).and_return([]) }
 


### PR DESCRIPTION
## Problem

The featured event was getting the expanded "featured" treatment (bigger card + a **Race Day Weather** heading) even when it was effectively more than 10 days out, leaving an empty weather block.

The cause is two different 10-day windows:

- **Featuring** (`is_featured?` → `is_close?`) checks the window in the **owner's current-location timezone**.
- **Weather fetch** (`event_weather_for`) computes `days_until` in the **event's own geocoded timezone** and only fetches a forecast when `days_until.between?(0, 10)`.

At the 10-day boundary these disagree, so an event can be flagged "featured" while no forecast was ever fetched. The `EventWeatherPresenter` is still non-`nil` (the event has coordinates), so the inline `_event_weather` partial renders its "Race Day Weather" heading with no actual forecast underneath.

## Fix

- In `EventsController#upcoming`, when an upcoming (not-today) featured event has no forecast (`@event_weather.forecast` blank), demote it to a regular upcoming race: clear `@featured`/`@event_weather` and trim the list back to the non-featured count of 3. Today's race keeps its own section regardless — it's race day.
- In `upcoming.html.erb`, pass the rendered `@upcoming.size` and `@featured` flag to `event_collection_variant` so the collection layout class reflects what the controller actually decided (instead of re-deriving from the helper, which doesn't know about the demotion).

## Tests

Added a request spec: when the next race is within the featured window but `WeatherKit` returns no data, the response renders it as a plain upcoming race — no `collection--has-featured`, no `event--is-featured`, no "Race Day Weather" block. Full events spec passes (the 5 failing `plausible_pageviews` specs are pre-existing and unrelated).

https://claude.ai/code/session_01LN8no8Vf2kqxcSGc4Ymyb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN8no8Vf2kqxcSGc4Ymyb8)_