### PR TITLE
Add Plausible first-party proxy redirects

### DIFF
--- a/web/lib/helpers/site_helpers.rb
+++ b/web/lib/helpers/site_helpers.rb
@@ -151,21 +151,30 @@ module SiteHelpers
     tag.pages.map { |t| t.items }.flatten.uniq.size
   end
 
-  # Checks if Plausible analytics is properly installed by verifying required redirects exist.
-  # @return [Boolean] True if both required Plausible redirects are present in data/redirects.json
+  # The Plausible first-party proxy rewrites baked into the Netlify `_redirects`
+  # file (emitted by source/redirects.erb). The analytics script loads from
+  # /js/script.js and events post to /api/event, both rewritten (status 200) to
+  # Plausible so they're served from this domain. The /api/event rule must match
+  # before the /api/* widget proxy function, so these are emitted ahead of the
+  # other redirects.
+  # @see https://plausible.io/docs/proxy/guides/netlify
+  PLAUSIBLE_PROXY_REDIRECTS = [
+    { from: '/js/script.js', to: 'https://plausible.io/js/pa-_6bvfc1qgJNBImkaSg1ZD.js', status: 200 },
+    { from: '/api/event', to: 'https://plausible.io/api/event', status: 200 }
+  ].freeze
+
+  # The Plausible proxy rewrite rules to emit into the `_redirects` file.
+  # @return [Array<Hash>] Each rule with :from, :to, and :status keys.
+  def plausible_proxy_redirects
+    PLAUSIBLE_PROXY_REDIRECTS
+  end
+
+  # Checks if Plausible analytics is installed, i.e. the first-party proxy
+  # rewrites are built into the site (see plausible_proxy_redirects). Gates the
+  # analytics script tag in partials/_analytics.html.erb.
+  # @return [Boolean] True when the Plausible proxy rewrites are configured.
   def is_plausible_installed?
-    return false unless data.redirects.present?
-    
-    required_redirects = [
-      { from: '/js/script.js', status: 200 },
-      { from: '/api/event', status: 200 }
-    ]
-    
-    required_redirects.all? do |required|
-      data.redirects.any? do |redirect|
-        redirect['from'] == required[:from] && redirect['status'] == required[:status]
-      end
-    end
+    plausible_proxy_redirects.present?
   end
 
   # Generates a JSON-LD schema string for the organization, based on the site data.

--- a/web/source/redirects.erb
+++ b/web/source/redirects.erb
@@ -1,3 +1,8 @@
+<%# Plausible analytics first-party proxy. Emitted first so the /api/event rewrite %>
+<%# is matched before the /api/* widget proxy function. See site_helpers.rb. %>
+<% plausible_proxy_redirects.each do |redirect| %>
+<%= redirect[:from] %> <%= redirect[:to] %> <%= redirect[:status] %>
+<% end %>
 <% data.articles.reject(&:draft).each do |article| %>
 /id/<%= article.sys.id %>/ <%= url_for article.path %> 301
 <% end %>


### PR DESCRIPTION
Sets up the Netlify rewrite rules to proxy Plausible analytics as a first-party connection, following [Plausible's Netlify proxy guide](https://plausible.io/docs/proxy/guides/netlify).

## What changed

Two rewrite rules are now emitted into the generated `_redirects` file (via `web/source/redirects.erb`):

| from | to | status |
|---|---|---|
| `/js/script.js` | the site-specific Plausible script (`pa-…js`) | `200` |
| `/api/event` | Plausible's event endpoint | `200` |

These match what the existing analytics code already expects: `partials/_analytics.html.erb` loads `<script defer src="/js/script.js">`, and the Plausible script's default event endpoint resolves to `/api/event` on this domain.

## Notes

- **Ordering / conflict with the `/api/*` proxy function.** The site already has a Netlify Function claiming `/api/*` (`netlify/functions/api-proxy.mts`), which overlaps the Plausible `/api/event` path. The rewrites are emitted **first** in `redirects.erb`, and Netlify evaluates `_redirects` rules top-to-bottom (first match wins) ahead of function `path` routes — so `/api/event` is proxied to Plausible while every other `/api/*` path still hits the widget proxy.
- **Single source of truth.** The rules live in a `PLAUSIBLE_PROXY_REDIRECTS` constant in `lib/helpers/site_helpers.rb`. Both `redirects.erb` (which emits them) and `is_plausible_installed?` (which gates the analytics `<script>` tag) read from it, so the script renders whenever the proxy is configured. `is_plausible_installed?` previously checked for these rules in Contentful's `data.redirects`; since they're now baked into the build, it checks the constant instead.
- The default `/js/script.js` and `/api/event` paths are kept to match the existing script tag and Plausible init. Plausible's guide warns these default names can be blocked by some blockers; switching to obfuscated paths would be a separate change touching `_analytics.html.erb` and `analytics.js`.

## Testing

`ruby -c` passes on the helper, and the new ERB block renders the expected `_redirects` lines. The bundled RSpec suite could not be run in this environment due to a Ruby version mismatch (env has 3.3.6, the Gemfile pins 4.0.5); the change touches no currently-tested helper.

https://claude.ai/code/session_01GBsEiBLTn2u6SvZn8fDP1X

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBsEiBLTn2u6SvZn8fDP1X)_