### PR TITLE
Harden Plausible loading and event tracking

### DIFF
--- a/web/lib/helpers/site_helpers.rb
+++ b/web/lib/helpers/site_helpers.rb
@@ -151,26 +151,46 @@ module SiteHelpers
     tag.pages.map { |t| t.items }.flatten.uniq.size
   end
 
-  # The Plausible first-party proxy rewrites baked into the Netlify `_redirects`
-  # file (emitted by source/redirects.erb).
+  # First-party proxy paths for Plausible analytics. Both the inline init
+  # snippet (partials/_analytics.html.erb) and the Netlify `_redirects` rewrites
+  # (source/redirects.erb) read these, so the browser-facing path and the proxy
+  # target stay in sync from a single source.
   # @see https://plausible.io/docs/proxy/guides/netlify
-  PLAUSIBLE_PROXY_REDIRECTS = [
-    { from: '/plsbl/script.js', to: ENV['PLAUSIBLE_SCRIPT_URL'], status: 200 },
-    { from: '/plsbl/event', to: 'https://plausible.io/api/event', status: 200 }
-  ].freeze
+  PLAUSIBLE_SCRIPT_PATH = '/plsbl/script.js'
+  PLAUSIBLE_EVENT_PATH = '/plsbl/event'
+  PLAUSIBLE_EVENT_UPSTREAM = 'https://plausible.io/api/event'
 
-  # The Plausible proxy rewrite rules to emit into the `_redirects` file.
-  # @return [Array<Hash>] Each rule with :from, :to, and :status keys.
-  def plausible_proxy_redirects
-    PLAUSIBLE_PROXY_REDIRECTS
+  # The first-party path the Plausible script is proxied from.
+  # @return [String]
+  def plausible_script_path
+    PLAUSIBLE_SCRIPT_PATH
   end
 
-  # Checks if Plausible analytics is installed, i.e. the first-party proxy
-  # rewrites are built into the site (see plausible_proxy_redirects). Gates the
-  # analytics script tag in partials/_analytics.html.erb.
-  # @return [Boolean] True when the Plausible proxy rewrites are configured.
+  # The first-party path Plausible events are sent to (the `endpoint` passed to
+  # `plausible.init`). Proxied to the upstream Plausible event API.
+  # @return [String]
+  def plausible_event_path
+    PLAUSIBLE_EVENT_PATH
+  end
+
+  # The Plausible proxy rewrite rules to emit into the `_redirects` file. Only
+  # built when an upstream script URL is configured (see is_plausible_installed?),
+  # so a missing `PLAUSIBLE_SCRIPT_URL` never emits a malformed rewrite line.
+  # @return [Array<Hash>] Each rule with :from, :to, and :status keys.
+  def plausible_proxy_redirects
+    return [] unless is_plausible_installed?
+    [
+      { from: PLAUSIBLE_SCRIPT_PATH, to: ENV['PLAUSIBLE_SCRIPT_URL'], status: 200 },
+      { from: PLAUSIBLE_EVENT_PATH, to: PLAUSIBLE_EVENT_UPSTREAM, status: 200 }
+    ]
+  end
+
+  # Checks if Plausible analytics is installed, i.e. the upstream script URL is
+  # configured so the first-party proxy can be built. Gates both the analytics
+  # script tag (partials/_analytics.html.erb) and the proxy rewrites.
+  # @return [Boolean] True when `PLAUSIBLE_SCRIPT_URL` is set.
   def is_plausible_installed?
-    plausible_proxy_redirects.present?
+    ENV['PLAUSIBLE_SCRIPT_URL'].present?
   end
 
   # Generates a JSON-LD schema string for the organization, based on the site data.

--- a/web/source/javascripts/stimulus/controllers/share_controller.js
+++ b/web/source/javascripts/stimulus/controllers/share_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
-import { trackEvent } from '../lib/analytics';
+import { trackEvent, trackEventThen } from '../lib/analytics';
 
 /**
  * Controller for managing social sharing functionality.
@@ -101,15 +101,19 @@ export default class extends Controller {
   trackShare(event) {
     event.preventDefault();
     const linkURL = this.element.href;
-
-    trackEvent('Share', { url: this.getShareUrl(), via: this.viaValue });
+    const props = { url: this.getShareUrl(), via: this.viaValue };
 
     // Handle special URL schemes (mailto:, sms:) differently than HTTP(S) URLs
     if (linkURL.startsWith('mailto:') || linkURL.startsWith('sms:')) {
-      // For mailto/sms, navigate in the current window to trigger the app
-      window.location.href = linkURL;
+      // For mailto/sms, navigating the current window can cancel an in-flight
+      // tracking request, so wait until the event is sent before navigating.
+      trackEventThen('Share', props, () => {
+        window.location.href = linkURL;
+      });
     } else {
-      // For HTTP(S) URLs, open in a new window/tab
+      // For HTTP(S) URLs, open in a new window/tab (the current page stays put,
+      // so the tracking request isn't interrupted).
+      trackEvent('Share', props);
       window.open(linkURL, '_blank', 'noopener,noreferrer');
     }
   }

--- a/web/source/javascripts/stimulus/lib/analytics.js
+++ b/web/source/javascripts/stimulus/lib/analytics.js
@@ -1,24 +1,14 @@
-/* global plausible */
-
-let plausibleInitialized = false;
-
 /**
- * Sets up the Plausible analytics queue if it doesn't already exist. Runs once per page load.
+ * Sends a call to Plausible if it's available. The queue stub and configuration
+ * are set up inline in the page head (partials/_analytics.html.erb) before the
+ * deferred script loads, so here we only need to guard against Plausible being
+ * absent (e.g. in development, where the script isn't injected), which turns
+ * every tracking call into a no-op instead of a ReferenceError.
+ * @param {...*} args - Arguments forwarded to `window.plausible`.
  */
-function setUpPlausible() {
-  if (plausibleInitialized) return;
-  window.plausible =
-    window.plausible ||
-    function () {
-      (window.plausible.q = window.plausible.q || []).push(arguments);
-    };
-  window.plausible.init =
-    window.plausible.init ||
-    function (i) {
-      window.plausible.o = i || {};
-    };
-  window.plausible.init({ autoCapturePageviews: false, endpoint: '/plsbl/event' });
-  plausibleInitialized = true;
+function track(...args) {
+  if (typeof window.plausible !== 'function') return;
+  window.plausible(...args);
 }
 
 /**
@@ -27,8 +17,6 @@ function setUpPlausible() {
  * @param {Object} additionalProps - Optional additional properties to include with the pageview.
  */
 export function trackPageView(additionalProps = {}) {
-  setUpPlausible();
-
   const currentUrl = new URL(window.location.href);
   const searchQuery = currentUrl.searchParams.get('q');
 
@@ -42,7 +30,7 @@ export function trackPageView(additionalProps = {}) {
     }
   }
 
-  plausible('pageview', params);
+  track('pageview', params);
   cleanUpUrl();
 }
 
@@ -53,8 +41,32 @@ export function trackPageView(additionalProps = {}) {
  * @param {Object} props - Additional properties to send with the event.
  */
 export function trackEvent(event, props = {}) {
-  setUpPlausible();
-  plausible(event, { props });
+  track(event, { props });
+}
+
+/**
+ * Tracks an event and then runs a callback, guaranteeing the callback runs even
+ * if the event can't be sent. Use this when the callback navigates the page away
+ * (e.g. `window.location.href = …`), which would otherwise cancel an in-flight
+ * tracking request. Relies on Plausible's `callback` option, with a short timeout
+ * as a fallback in case the callback never fires (or Plausible isn't loaded).
+ * @param {string} event - The event name to be tracked.
+ * @param {Object} props - Additional properties to send with the event.
+ * @param {Function} done - Callback to run once the event is sent (or times out).
+ */
+export function trackEventThen(event, props, done) {
+  let ran = false;
+  const go = () => {
+    if (ran) return;
+    ran = true;
+    done();
+  };
+
+  if (typeof window.plausible !== 'function') return go();
+
+  track(event, { props, callback: go });
+  // Fallback so navigation isn't blocked if the callback never fires.
+  setTimeout(go, 150);
 }
 
 /**

--- a/web/source/partials/_analytics.html.erb
+++ b/web/source/partials/_analytics.html.erb
@@ -1,3 +1,11 @@
 <% if is_production? && is_plausible_installed? %>
-  <script defer src="/plsbl/script.js"></script>
+  <%# Register Plausible's config inline, before the deferred script loads, so our %>
+  <%# settings (manual pageviews + first-party endpoint) apply before the script can %>
+  <%# auto-initialize with its defaults (autoCapturePageviews:true, public endpoint). %>
+  <script>
+    window.plausible = window.plausible || function () { (window.plausible.q = window.plausible.q || []).push(arguments) };
+    window.plausible.init = window.plausible.init || function (i) { window.plausible.o = i || {} };
+    plausible.init({ autoCapturePageviews: false, endpoint: '<%= plausible_event_path %>' });
+  </script>
+  <script defer src="<%= plausible_script_path %>"></script>
 <% end %>

--- a/web/source/redirects.erb
+++ b/web/source/redirects.erb
@@ -1,5 +1,5 @@
-<%# Plausible analytics first-party proxy. Emitted first so the /api/event rewrite %>
-<%# is matched before the /api/* widget proxy function. See site_helpers.rb. %>
+<%# Plausible analytics first-party proxy (/plsbl/*). Emitted first so a catch-all %>
+<%# redirect from Contentful (below) can't shadow these rewrites. See site_helpers.rb. %>
 <% plausible_proxy_redirects.each do |redirect| %>
 <%= redirect[:from] %> <%= redirect[:to] %> <%= redirect[:status] %>
 <% end %>


### PR DESCRIPTION
## Why

Auditing how Plausible is loaded in `web/` surfaced a load-order race plus a config bug that could drop or duplicate pageviews and defeat the adblock-bypass first-party proxy.

The core problem: Plausible's new script defaults to `autoCapturePageviews: true` and `endpoint: https://plausible.io/api/event` (the public, adblock-blocked URL). The app overrode these with `init({ autoCapturePageviews: false, endpoint: '/plsbl/event' })`, but **lazily** — inside the deferred `site.js` bundle, only on the first `turbo:load`, which runs *after* the deferred `/plsbl/script.js` has already executed. So the script could auto-initialize with its defaults first, risking a duplicate auto-pageview sent to the non-proxied endpoint.

## Changes

- **Initialize Plausible inline in the `<head>`** (`_analytics.html.erb`), before the deferred script, following Plausible's documented install pattern — so our manual-pageview + first-party-endpoint config is registered before the script can self-init. Kills the pageview race and the double-count.
- **Fix the install guard** (`site_helpers.rb`): `is_plausible_installed?` now requires `PLAUSIBLE_SCRIPT_URL` to actually be set. It previously returned `true` off a constant array, emitting a broken `<script>` tag and a malformed `_redirects` line whenever the env var was missing (e.g. deploy previews / misconfig).
- **Centralize the `/plsbl/*` proxy paths** in `site_helpers.rb` so the inline init endpoint and the `_redirects` rewrites share one source of truth.
- **Slim `analytics.js`** to a guarded call-through (`track(...)`), now that setup lives in the head. Calls become a clean no-op when Plausible is absent (e.g. in development) instead of throwing.
- **Stop dropping the Share event on `mailto:`/`sms:` navigation**: new `trackEventThen()` helper uses Plausible's `callback` option (with a short timeout fallback) to flush the event before `window.location.href` navigates the page away.
- **Cleanup**: refresh the stale `/api/event` comment in `redirects.erb` (the path is `/plsbl/event` now; the real reason it's emitted first is so a Contentful catch-all can't shadow it).

No new tracking features and no JS test harness, per scoping.

## Verification

- `analytics.js` and `share_controller.js` bundle cleanly via esbuild; `prettier --check` passes on both.
- Ruby + ERB syntax checks pass; helper logic verified manually: with `PLAUSIBLE_SCRIPT_URL` unset → `is_plausible_installed? == false` and no rewrites emitted; set → well-formed `/plsbl/script.js` and `/plsbl/event` lines.
- Note: the full `rake build:verbose` / `rake test` couldn't run in this environment (Ruby 4.0.5 not installed; Web Awesome Pro private registry unavailable). Worth a local `bundle exec rake build:verbose` + a browser Network-tab check (exactly one `pageview` POST to `/plsbl/event` per navigation, none to the public endpoint) before merge.

https://claude.ai/code/session_012Qrjc5cTiwHEk8v7Ugra9a

---
_Generated by [Claude Code](https://claude.ai/code/session_012Qrjc5cTiwHEk8v7Ugra9a)_