### PR TITLE
Add Bugsnag error reporting to the API app

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -84,3 +84,7 @@ BLUESKY_HANDLE=
 BLUESKY_APP_PASSWORD=
 # Optional PDS host; defaults to https://bsky.social.
 BLUESKY_PDS_URL=
+
+# Bugsnag project API key for error reporting. Only production notifies; unset locally
+# and in CI, where exception reporting is a no-op.
+BUGSNAG_API_KEY=

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -65,6 +65,10 @@ headers below. Edge TTL = how long Netlify serves a cached copy before revalidat
   successful, cacheable responses. Edge `stale-while-revalidate` defaults to one hour
   (`DEFAULT_EDGE_STALE_WHILE_REVALIDATE`); the pageviews and upcoming-races widgets pass
   `edge_stale_while_revalidate: 1.day` since their data barely changes.
+- **Error reporting** — `config/initializers/bugsnag.rb` wires the `bugsnag` gem; its railtie
+  auto-inserts the Rack middleware and hooks ActionDispatch, so unhandled exceptions are
+  reported even though errors render as plain text. `notify_release_stages` is limited to
+  `production` and `BUGSNAG_API_KEY` is unset locally/in CI, so it's a no-op outside production.
 - **Errors** render as plain text via `lib/plain_text_exceptions.rb`. Unmatched paths are
   caught by the trailing `match "*unmatched"` route → `ApplicationController#route_not_found`
   (plain-text 404), instead of raising `ActionController::RoutingError`. This is what keeps
@@ -128,6 +132,8 @@ secrets (and Rails `config/credentials.yml.enc` + `master.key`).
 - **Optional**: `FONT_AWESOME_VERSION`, `WHOOP_REFERRAL_URL`, `TRAINERROAD_CALENDAR_URL`,
   `PURPLEAIR_API_KEY`, `LOCATION`, `TIME_ZONE`, `BLUESKY_HANDLE`, `BLUESKY_APP_PASSWORD`,
   `BLUESKY_PDS_URL` (standard.site publishing; no-ops when the handle/password are unset),
+  `BUGSNAG_API_KEY` (error reporting; **production only** — notifies only in the production
+  release stage, and is unset in development/CI, so it's a no-op there),
   `ALLOWED_HOSTS` (comma-separated `Host`-header allowlist; **production only**, enables
   host authorization. Unset = all hosts accepted, so it's safe to deploy before setting it,
   then activate by setting the fly secret. `/up` is always exempt. Never hardcode the host).

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -30,6 +30,9 @@ gem "rack-timeout"
 # Blocks/throttles abusive direct-to-origin requests (vulnerability scanners) at the edge of
 # the middleware stack, before they reach routing. See config/initializers/rack_attack.rb.
 gem "rack-attack"
+# Reports unhandled exceptions to Bugsnag (production only). See
+# config/initializers/bugsnag.rb.
+gem "bugsnag"
 # GraphQL client for the Font Awesome API
 gem "graphql-client"
 

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     bigdecimal (4.1.2)
     brakeman (8.0.4)
       racc
+    bugsnag (6.30.0)
+      concurrent-ruby (~> 1.0)
     builder (3.3.0)
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
@@ -294,6 +296,7 @@ PLATFORMS
 
 DEPENDENCIES
   brakeman
+  bugsnag
   bundler-audit
   debug
   dotenv-rails
@@ -329,6 +332,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  bugsnag (6.30.0) sha256=c496cfceb4a9811ce718b0d2ff66c5a35d158804b79e60c3d2ba12d9084ff19e
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/api/config/initializers/bugsnag.rb
+++ b/api/config/initializers/bugsnag.rb
@@ -1,0 +1,11 @@
+# Reports unhandled exceptions to Bugsnag. The gem's railtie auto-inserts its Rack
+# middleware and hooks ActionDispatch's exception handling, so exceptions are captured
+# even though this API renders errors as plain text (lib/plain_text_exceptions.rb).
+#
+# Only production actually notifies: notify_release_stages is limited to "production",
+# and BUGSNAG_API_KEY is unset in development/test, so this is a no-op locally and in CI.
+Bugsnag.configure do |config|
+  config.api_key = ENV["BUGSNAG_API_KEY"]
+  config.release_stage = Rails.env
+  config.notify_release_stages = %w[production]
+end


### PR DESCRIPTION
## What

Adds [Bugsnag](https://docs.bugsnag.com/platforms/ruby/) error reporting to the `api/` Rails app so unhandled exceptions are reported from the fly.io origin.

## Changes

- **`api/Gemfile`** — adds `gem "bugsnag"` (and `Gemfile.lock`).
- **`api/config/initializers/bugsnag.rb`** — configures the API key from `BUGSNAG_API_KEY` and limits `notify_release_stages` to `production`.
- **`api/.env.example`** — documents the new optional `BUGSNAG_API_KEY`.
- **`api/CLAUDE.md`** — documents the integration in the Architecture and Environment-variables sections.

## How it works

The `bugsnag` gem's railtie auto-inserts its Rack middleware and hooks ActionDispatch's exception handling, so exceptions are captured even though this API renders errors as plain text via `lib/plain_text_exceptions.rb` (verified `Bugsnag::Rack` is present in the middleware stack on boot).

`notify_release_stages` is limited to `production`, and `BUGSNAG_API_KEY` is unset locally and in CI, so reporting is a **no-op outside production** — safe to merge and deploy before the fly secret is set, then activate by setting `BUGSNAG_API_KEY`.

## Verification

- `bundle exec rspec` — **416 examples, 0 failures**
- `brakeman -q` — **0 security warnings**
- `bundle-audit check --update` — **no vulnerabilities** (incl. the new gem)
- App boots; the initializer applies (`notify_release_stages == ["production"]`) and `Bugsnag::Rack` is in the middleware stack.

https://claude.ai/code/session_014eqFqXhv14cDRUJ8JsukGc

---
_Generated by [Claude Code](https://claude.ai/code/session_014eqFqXhv14cDRUJ8JsukGc)_