### PR TITLE
Report upstream-API failures to Bugsnag

### DIFF
--- a/api/app/services/application_service.rb
+++ b/api/app/services/application_service.rb
@@ -51,7 +51,10 @@ class ApplicationService
   # @param response [HTTParty::Response]
   # @return [Object, nil] The parsed body, or nil when the response was not successful.
   def parse_json(response, symbolize: true)
-    return unless response.success?
+    unless response.success?
+      report_upstream_error("HTTP #{response.code}", status: response.code, url: response.request&.last_uri&.to_s)
+      return
+    end
 
     JSON.parse(response.body, symbolize_names: symbolize)
   end
@@ -69,12 +72,13 @@ class ApplicationService
     attempts = 0
     begin
       yield
-    rescue StandardError
+    rescue StandardError => e
       attempts += 1
       if attempts <= max
         sleep(2**attempts)
         retry
       end
+      report_upstream_error(e)
       nil
     end
   end
@@ -86,6 +90,15 @@ class ApplicationService
     yield
   rescue StandardError => e
     Rails.logger.error("#{context}: #{e}")
+    report_upstream_error(e, context: context)
     fallback
+  end
+
+  # Reports a handled upstream-API failure to Bugsnag, tagged with this service's class name.
+  # Thin wrapper over ErrorReporter so subclasses don't repeat the service: argument. Purely
+  # additive — callers keep their existing logging and graceful-degradation return values.
+  # @see ErrorReporter.report_upstream
+  def report_upstream_error(error, context: self.class.name, status: nil, url: nil)
+    ErrorReporter.report_upstream(error, service: self.class.name, context: context, status: status, url: url)
   end
 end

--- a/api/app/services/error_reporter.rb
+++ b/api/app/services/error_reporter.rb
@@ -1,0 +1,62 @@
+require "uri"
+
+# Central place for reporting *handled* upstream-API failures to Bugsnag. The service layer
+# deliberately degrades gracefully — non-2xx responses, expired tokens, rate limiting,
+# timeouts, and network errors are swallowed so widgets collapse instead of crashing — which
+# means none of them ever reach a controller and Bugsnag's auto-instrumentation never sees
+# them. This module makes those failures visible without changing that behavior.
+#
+# Callable from both ApplicationService subclasses (via the report_upstream_error wrapper)
+# and the FontAwesomeClient module, which is not a service object.
+module ErrorReporter
+  module_function
+
+  # Reports a handled upstream-API failure to Bugsnag at "warning" severity (kept distinct
+  # from the genuine unhandled crashes that surface as "error"). A no-op outside production,
+  # since Bugsnag's notify_release_stages is limited to production and BUGSNAG_API_KEY is
+  # unset locally/in CI. Never raises into the caller — error reporting must not break the
+  # request path.
+  #
+  # @param error [Exception, String] The rescued exception, or a message for a non-2xx
+  #   response (which isn't an exception).
+  # @param service [String] The reporting service class/module name.
+  # @param context [String, nil] Optional label for what was being attempted.
+  # @param status [Integer, nil] The upstream HTTP status code, when applicable.
+  # @param url [String, nil] The upstream URL; sanitized to host+path before reporting.
+  def report_upstream(error, service:, context: nil, status: nil, url: nil)
+    exception = error.is_a?(Exception) ? error : UpstreamError.new(error.to_s)
+    Bugsnag.notify(exception) do |report|
+      report.severity = "warning"
+      report.add_metadata(:upstream, {
+        service: service,
+        context: context,
+        status: status,
+        url: sanitize_url(url)
+      }.compact)
+    end
+  rescue StandardError => e
+    Rails.logger.error("ErrorReporter: failed to notify Bugsnag: #{e}")
+  end
+
+  # Reduces a URL to scheme+host+path, dropping the query string.
+  #
+  # ⚠️ SECURITY: the Google APIs put their API key in the query string, so the raw URL must
+  # never be shipped to Bugsnag. Request/response bodies (which can hold OAuth secrets and
+  # tokens) are likewise never reported — the status code, sanitized URL, and service name
+  # are enough to triage.
+  #
+  # @param url [String, nil]
+  # @return [String, nil]
+  def sanitize_url(url)
+    return if url.blank?
+
+    uri = URI.parse(url.to_s)
+    "#{uri.scheme}://#{uri.host}#{uri.path}"
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  # Stable, greppable class for the non-exception (non-2xx response) reports so they group
+  # together in Bugsnag rather than scattering across ad-hoc RuntimeErrors.
+  class UpstreamError < StandardError; end
+end

--- a/api/app/services/font_awesome.rb
+++ b/api/app/services/font_awesome.rb
@@ -33,6 +33,7 @@ class FontAwesome
     svg
   rescue StandardError => e
     Rails.logger.error("Error fetching Font Awesome icon #{icon_id}: #{e}")
+    ErrorReporter.report_upstream(e, service: "FontAwesome", context: "Font Awesome icon #{icon_id}")
     nil
   end
 

--- a/api/app/services/font_awesome_client.rb
+++ b/api/app/services/font_awesome_client.rb
@@ -36,13 +36,17 @@ module FontAwesomeClient
       }
 
       response = HTTParty.post("#{FONT_AWESOME_API_URL}/token", headers: headers)
-      return unless response.success?
+      unless response.success?
+        ErrorReporter.report_upstream("HTTP #{response.code}", service: "FontAwesomeClient", context: "Font Awesome token", status: response.code, url: "#{FONT_AWESOME_API_URL}/token")
+        return
+      end
 
       data = JSON.parse(response.body, symbolize_names: true)
       $redis.setex("font_awesome:access_token", data[:expires_in], data[:access_token])
       data[:access_token]
     rescue StandardError => e
       Rails.logger.error("Error fetching the Font Awesome access token: #{e}")
+      ErrorReporter.report_upstream(e, service: "FontAwesomeClient", context: "Font Awesome token")
       nil
     end
 

--- a/api/app/services/standard_site.rb
+++ b/api/app/services/standard_site.rb
@@ -500,6 +500,7 @@ class StandardSite < ApplicationService
     )
     unless response.success?
       Rails.logger.warn("standard.site: failed to authenticate with the PDS (HTTP #{response.code})")
+      report_upstream_error("HTTP #{response.code}", context: "standard.site PDS session", status: response.code)
       return false
     end
     data = JSON.parse(response.body)
@@ -510,6 +511,7 @@ class StandardSite < ApplicationService
     @access_jwt.present? && @did.present?
   rescue StandardError => e
     Rails.logger.error("standard.site: error creating PDS session: #{e.message}")
+    report_upstream_error(e, context: "standard.site PDS session")
     false
   end
 
@@ -531,7 +533,10 @@ class StandardSite < ApplicationService
       body: { repo: @did, collection: collection, rkey: rkey, validate: false, record: record }.to_json,
       headers: auth_headers
     )
-    Rails.logger.warn("standard.site: failed to put #{collection}/#{rkey} (HTTP #{response.code}: #{response.body})") unless response.success?
+    unless response.success?
+      Rails.logger.warn("standard.site: failed to put #{collection}/#{rkey} (HTTP #{response.code}: #{response.body})")
+      report_upstream_error("HTTP #{response.code}", context: "standard.site putRecord #{collection}/#{rkey}", status: response.code)
+    end
     response.success?
   end
 
@@ -554,7 +559,10 @@ class StandardSite < ApplicationService
       query = { repo: @did, collection: collection, limit: 100 }
       query[:cursor] = cursor if cursor.present?
       response = HTTParty.get("#{@service_url}/xrpc/com.atproto.repo.listRecords", query: query, headers: auth_headers)
-      break unless response.success?
+      unless response.success?
+        report_upstream_error("HTTP #{response.code}", context: "standard.site listRecords #{collection}", status: response.code)
+        break
+      end
       body = JSON.parse(response.body)
       records = Array(body["records"])
       rkeys.concat(records.map { |r| r["uri"].to_s.split("/").last })
@@ -587,9 +595,13 @@ class StandardSite < ApplicationService
       body: bytes,
       headers: { "Content-Type" => mime, "Authorization" => "Bearer #{@access_jwt}" }
     )
-    return unless response.success?
+    unless response.success?
+      report_upstream_error("HTTP #{response.code}", context: "standard.site uploadBlob", status: response.code)
+      return
+    end
     JSON.parse(response.body)["blob"]
-  rescue StandardError
+  rescue StandardError => e
+    report_upstream_error(e, context: "standard.site uploadBlob")
     nil
   end
 
@@ -602,10 +614,15 @@ class StandardSite < ApplicationService
     source = url.to_s.start_with?("//") ? "https:#{url}" : url
     format = content_type == "image/png" ? "png" : "jpg"
     mime = format == "png" ? "image/png" : "image/jpeg"
-    response = HTTParty.get(images_api_url(source, w: w, h: h, fm: format))
-    return unless response.success?
+    image_url = images_api_url(source, w: w, h: h, fm: format)
+    response = HTTParty.get(image_url)
+    unless response.success?
+      report_upstream_error("HTTP #{response.code}", context: "standard.site image fetch", status: response.code, url: image_url)
+      return
+    end
     [response.body, mime]
-  rescue StandardError
+  rescue StandardError => e
+    report_upstream_error(e, context: "standard.site image fetch")
     nil
   end
 

--- a/api/app/services/trainer_road.rb
+++ b/api/app/services/trainer_road.rb
@@ -19,7 +19,10 @@ class TrainerRoad < ApplicationService
     cache_key = "trainerroad:workouts:#{@timezone}:#{CALENDAR_URL.parameterize}"
     cached_json(cache_key, expires_in: 5.minutes) do
       response = HTTParty.get(CALENDAR_URL)
-      next [] unless response.success?
+      unless response.success?
+        report_upstream_error("HTTP #{response.code}", context: "TrainerRoad calendar", status: response.code)
+        next []
+      end
 
       calendar = Icalendar::Calendar.parse(response.body).first
       today = Time.current.in_time_zone(@timezone).to_date

--- a/api/app/services/weather_kit.rb
+++ b/api/app/services/weather_kit.rb
@@ -101,7 +101,8 @@ class WeatherKit < ApplicationService
 
     private_key = OpenSSL::PKey::EC.new(private_key_content)
     JWT.encode(claims, private_key, "ES256", header)
-  rescue StandardError
+  rescue StandardError => e
+    report_upstream_error(e, context: "WeatherKit JWT generation")
     nil
   end
 end

--- a/api/app/services/whoop.rb
+++ b/api/app/services/whoop.rb
@@ -83,6 +83,7 @@ class Whoop < ApplicationService
     token_data
   rescue StandardError => e
     Rails.logger.error("Error exchanging Whoop authorization code: #{e}")
+    report_upstream_error(e, context: "Whoop OAuth code exchange")
     nil
   end
 
@@ -190,6 +191,7 @@ class Whoop < ApplicationService
 
     unless response.success?
       Rails.logger.warn("Failed to refresh Whoop access token (HTTP #{response.code}). Visit /whoop/auth to re-authorize.")
+      report_upstream_error("HTTP #{response.code}", context: "Whoop token refresh", status: response.code)
       return
     end
 
@@ -198,6 +200,7 @@ class Whoop < ApplicationService
     token_data[:access_token]
   rescue StandardError => e
     Rails.logger.error("Error refreshing Whoop token: #{e}")
+    report_upstream_error(e, context: "Whoop token refresh")
     nil
   end
 

--- a/api/spec/services/application_service_spec.rb
+++ b/api/spec/services/application_service_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe ApplicationService do
   end
   let(:service) { service_class.new }
 
-  def response_double(success:, body:)
-    instance_double(HTTParty::Response, success?: success, body: body)
+  def response_double(success:, body:, code: 200, url: "https://example.test/path")
+    request = instance_double(HTTParty::Request, last_uri: URI.parse(url))
+    instance_double(HTTParty::Response, success?: success, body: body, code: code, request: request)
   end
 
   describe "#cached_json" do
@@ -90,6 +91,23 @@ RSpec.describe ApplicationService do
       expect(service.http_get("https://example.test")).to be_nil
     end
 
+    it "reports a non-success response to Bugsnag with its status code and url" do
+      allow(HTTParty).to receive(:get)
+        .and_return(response_double(success: false, body: "nope", code: 429, url: "https://upstream.test/data?key=secret"))
+      message, kwargs = nil
+      allow(ErrorReporter).to receive(:report_upstream) { |msg, **kw| message = msg; kwargs = kw }
+
+      expect(service.http_get("https://upstream.test/data")).to be_nil
+      expect(message).to eq("HTTP 429")
+      expect(kwargs).to include(status: 429, url: "https://upstream.test/data?key=secret")
+    end
+
+    it "does not report a successful response" do
+      allow(HTTParty).to receive(:get).and_return(response_double(success: true, body: '{"a":1}'))
+      expect(ErrorReporter).not_to receive(:report_upstream)
+      service.http_get("https://example.test")
+    end
+
     it "posts and parses with string keys when symbolize: false" do
       allow(HTTParty).to receive(:post).and_return(response_double(success: true, body: '{"a":1}'))
       expect(service.http_post("https://example.test", symbolize: false)).to eq("a" => 1)
@@ -122,6 +140,21 @@ RSpec.describe ApplicationService do
       expect(result).to be_nil
       expect(calls).to eq(3) # initial + 2 retries
     end
+
+    it "reports the error to Bugsnag once, only after the retries are exhausted" do
+      reported = nil
+      allow(ErrorReporter).to receive(:report_upstream) { |err, **| reported = err }
+      service.retrying(max: 2) { raise "boom" }
+      expect(ErrorReporter).to have_received(:report_upstream).once
+      expect(reported).to be_a(RuntimeError).and have_attributes(message: "boom")
+    end
+
+    it "does not report when the block eventually succeeds" do
+      expect(ErrorReporter).not_to receive(:report_upstream)
+      attempts = 0
+      result = service.retrying(max: 2) { attempts += 1; raise "boom" if attempts < 2; "ok" }
+      expect(result).to eq("ok")
+    end
   end
 
   describe "#rescue_with" do
@@ -132,6 +165,17 @@ RSpec.describe ApplicationService do
     it "logs and returns the fallback when the block raises" do
       expect(Rails.logger).to receive(:error).with(/boom/)
       expect(service.guarded([], context: "ctx") { raise "boom" }).to eq([])
+    end
+
+    it "reports the error to Bugsnag in addition to logging" do
+      allow(Rails.logger).to receive(:error)
+      reported = nil
+      context = nil
+      allow(ErrorReporter).to receive(:report_upstream) { |err, **kw| reported = err; context = kw[:context] }
+
+      service.guarded([], context: "ctx") { raise "boom" }
+      expect(reported).to be_a(RuntimeError).and have_attributes(message: "boom")
+      expect(context).to eq("ctx")
     end
   end
 end

--- a/api/spec/services/error_reporter_spec.rb
+++ b/api/spec/services/error_reporter_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe ErrorReporter do
+  describe ".report_upstream" do
+    # A stand-in for the Bugsnag::Report yielded to the notify block.
+    let(:report) { double("Bugsnag::Report", :severity= => nil, add_metadata: nil) }
+
+    it "notifies Bugsnag at warning severity with the upstream metadata" do
+      allow(Bugsnag).to receive(:notify) { |_exception, &block| block.call(report) }
+
+      described_class.report_upstream(
+        ArgumentError.new("nope"),
+        service: "Whoop", context: "token refresh", status: 401, url: "https://x.test/y?key=secret"
+      )
+
+      expect(report).to have_received(:severity=).with("warning")
+      expect(report).to have_received(:add_metadata).with(
+        :upstream,
+        { service: "Whoop", context: "token refresh", status: 401, url: "https://x.test/y" }
+      )
+    end
+
+    it "passes an exception through to Bugsnag unchanged" do
+      error = ArgumentError.new("nope")
+      expect(Bugsnag).to receive(:notify).with(error)
+      described_class.report_upstream(error, service: "Whoop")
+    end
+
+    it "wraps a non-exception message in an UpstreamError" do
+      expect(Bugsnag).to receive(:notify).with(an_instance_of(ErrorReporter::UpstreamError)) do |exception|
+        expect(exception.message).to eq("HTTP 500")
+      end
+      described_class.report_upstream("HTTP 500", service: "WeatherKit")
+    end
+
+    it "omits nil metadata fields so only what's known is reported" do
+      allow(Bugsnag).to receive(:notify) { |_exception, &block| block.call(report) }
+      described_class.report_upstream("HTTP 503", service: "Goodspeed")
+      expect(report).to have_received(:add_metadata).with(:upstream, { service: "Goodspeed" })
+    end
+
+    it "never raises into the caller when Bugsnag itself fails" do
+      allow(Bugsnag).to receive(:notify).and_raise("bugsnag unavailable")
+      expect(Rails.logger).to receive(:error).with(/ErrorReporter/)
+      expect { described_class.report_upstream("HTTP 500", service: "X") }.not_to raise_error
+    end
+  end
+
+  describe ".sanitize_url" do
+    it "drops the query string so credentials are never reported" do
+      expect(described_class.sanitize_url("https://maps.googleapis.com/geo/json?key=SECRET&latlng=1,2"))
+        .to eq("https://maps.googleapis.com/geo/json")
+    end
+
+    it "keeps the scheme, host, and path" do
+      expect(described_class.sanitize_url("https://api.example.test/v1/widgets"))
+        .to eq("https://api.example.test/v1/widgets")
+    end
+
+    it "returns nil for a blank url" do
+      expect(described_class.sanitize_url(nil)).to be_nil
+      expect(described_class.sanitize_url("")).to be_nil
+    end
+
+    it "returns nil for an unparseable url instead of raising" do
+      expect(described_class.sanitize_url("http://exa mple.test/bad")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

The `api/` app wires up Bugsnag, but the integration is **purely auto-instrumented** — the gem's Rack middleware only sees exceptions that bubble out of a controller. The service layer deliberately **degrades gracefully**: every external-API client swallows upstream problems (non-2xx responses, 401 expired tokens, 429 rate limiting, timeouts, network errors), logs at most a `Rails.logger` line, and returns `nil`/`[]` so the widget collapses instead of crashing. Because nothing reaches a controller, **Bugsnag never heard about any of it** — these failures were invisible in production.

This PR makes upstream-API failures visible **without changing the graceful-degradation behavior** (widgets still collapse on failure) — it's purely additive observability.

## Changes

- **New `ErrorReporter` module** (`app/services/error_reporter.rb`) — a shared, no-raise reporter callable from both `ApplicationService` subclasses and the `FontAwesomeClient` module. Notifies Bugsnag at **`warning` severity** (kept distinct from genuine unhandled crashes, which stay `error`) and attaches an `upstream` metadata tab (service, context, status, sanitized URL). A no-op outside production, as before.
- **Central helpers** (`application_service.rb`) — `parse_json` now reports every non-2xx response; `with_retries` reports the error once retries are exhausted; `rescue_with` reports in addition to logging. This covers most clients (Intervals, Plausible, Google Maps/AQI/Pollen, PurpleAir, Goodspeed, Articles, Events, WeatherKit-via-retries, Whoop data fetches).
- **Clients that bypass the central helpers** with their own `response.success?`/`rescue` are instrumented individually: Whoop OAuth (token refresh/exchange — the expired-token case), WeatherKit JWT generation, Font Awesome (token + icon fetch), standard.site PDS (session/putRecord/listRecords/blob/image), and TrainerRoad.

## Security

⚠️ URLs are reduced to **scheme + host + path** before reporting — the query string is dropped, so the API keys some upstreams (e.g. Google) carry in the query string are never shipped to Bugsnag. Request/response bodies (which can hold OAuth secrets and tokens) are never reported either; status code + sanitized URL + service name are enough to triage.

## Decisions (confirmed with maintainer)

- **Scope:** report *every* non-2xx response plus any raised/rescued exception. ("Expected empty" cases like Google `ZERO_RESULTS` / PurpleAir no-sensor come back as 200-with-empty-body, so non-2xx reporting won't generate noise from them.)
- **Severity:** `warning`, to keep handled degradation distinct from real crashes.

## Testing

- New `spec/services/error_reporter_spec.rb` — severity/metadata, query-string stripping, blank/invalid URL handling, and that a Bugsnag failure never raises into the caller.
- Extended `spec/services/application_service_spec.rb` — `parse_json` reports non-2xx (with status + url), `with_retries` reports once after exhaustion (not on eventual success), `rescue_with` reports in addition to logging.
- `bundle exec rspec spec/services` → **99 examples, 0 failures**. The only full-suite failures are 5 pre-existing `plausible_pageviews` request specs that also fail on the clean `main` tree (environment/Ruby-version mismatch in the runner), untouched by this change.

https://claude.ai/code/session_01YBtiDphMKWckRugg5EnrDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBtiDphMKWckRugg5EnrDp)_