### PR TITLE
Add Known Agents edge function for server-side agent analytics

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -68,6 +68,9 @@ to flush the cache.
   `source/javascripts/stimulus/`, `source/stylesheets/`.
 - `netlify/functions/` — `api-proxy.mts` (proxies `/api/*`; see root `CLAUDE.md`),
   `og.mts` (OG images), `robots.mts` (serves `/robots.txt` with live Dark Visitors rules).
+- `netlify/edge-functions/` — `known-agents.ts` (records every page view server-side to
+  Known Agents / Dark Visitors, capturing bot + AI-agent traffic Plausible can't see;
+  production-only, reuses `DARK_VISITORS_ACCESS_TOKEN`).
 - `data/font_awesome.yml` — **icon allowlist**. Any new icon must be added here (under
   the correct family/style, e.g. `classic.light`) before `icon_svg` / `rake import:icons`
   can use it.

--- a/web/netlify/edge-functions/known-agents.ts
+++ b/web/netlify/edge-functions/known-agents.ts
@@ -1,0 +1,108 @@
+import type { Config, Context } from '@netlify/edge-functions';
+
+// Records every page request server-side with Known Agents (the Dark Visitors company,
+// using the same DARK_VISITORS_ACCESS_TOKEN as robots.mts). This captures bots, AI
+// crawlers, and LLM-referral traffic that never execute the client-side Plausible JS,
+// so it complements — not replaces — that analytics. Mirrors the documented Cloudflare
+// Worker pattern: time the request, then POST the visit in the background.
+const KNOWN_AGENTS_API_URL = 'https://api.knownagents.com/visits';
+
+// Don't forward headers that carry secrets or per-viewer identity to the analytics API.
+const SENSITIVE_HEADERS = new Set(['cookie', 'authorization']);
+
+function headersToObject(headers: Headers, omit?: Set<string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of headers) {
+    if (omit?.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+// Never throws into the request path: any failure (network, non-2xx, bad token) is
+// swallowed so tracking can't break or delay a page view.
+async function trackVisit(
+  request: Request,
+  response: Response,
+  durationMs: number,
+  token: string,
+): Promise<void> {
+  try {
+    const url = new URL(request.url);
+    await fetch(KNOWN_AGENTS_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        request_path: url.pathname,
+        request_method: request.method,
+        request_headers: headersToObject(request.headers, SENSITIVE_HEADERS),
+        response_status_code: response.status,
+        response_headers: { 'content-type': response.headers.get('content-type') ?? '' },
+        response_duration_in_milliseconds: durationMs,
+      }),
+    });
+  } catch (error) {
+    console.error('Known Agents tracking failed:', error);
+  }
+}
+
+export default async function handler(request: Request, context: Context): Promise<Response> {
+  const token = Deno.env.get('DARK_VISITORS_ACCESS_TOKEN');
+
+  // Fail open: no token, or not a production deploy → pass straight through, untracked.
+  // (Skipping previews/branch deploys keeps bot scans of those URLs out of the dataset.)
+  if (!token || Deno.env.get('CONTEXT') !== 'production') {
+    return context.next();
+  }
+
+  const start = Date.now();
+  // The downstream static page / CDN response, returned to the client unchanged.
+  const response = await context.next();
+  const durationMs = Date.now() - start;
+
+  // Background work: waitUntil keeps the edge worker alive to finish the POST *after*
+  // the response is sent, so tracking adds no latency to the page.
+  context.waitUntil(trackVisit(request, response, durationMs, token));
+
+  return response;
+}
+
+export const config: Config = {
+  // Run on every request, then exclude everything that isn't a real page view:
+  // built assets, the other Netlify functions, the Plausible proxy, and feeds.
+  path: '/*',
+  excludedPath: [
+    '/javascripts/*',
+    '/stylesheets/*',
+    '/images/*',
+    '/fonts/*',
+    '/api/*',
+    '/og',
+    '/robots.txt',
+    '/plsbl/*',
+    '/sitemap.xml',
+    '/feed.xml',
+    '/.well-known/*',
+    '/favicon.ico',
+    '/*.png',
+    '/*.jpg',
+    '/*.jpeg',
+    '/*.gif',
+    '/*.svg',
+    '/*.webp',
+    '/*.avif',
+    '/*.ico',
+    '/*.woff',
+    '/*.woff2',
+    '/*.ttf',
+    '/*.css',
+    '/*.js',
+    '/*.json',
+    '/*.xml',
+    '/*.txt',
+    '/*.map',
+  ],
+};

--- a/web/netlify/edge-functions/known-agents.ts
+++ b/web/netlify/edge-functions/known-agents.ts
@@ -71,8 +71,11 @@ export default async function handler(request: Request, context: Context): Promi
 }
 
 export const config: Config = {
-  // Run on every request, then exclude everything that isn't a real page view:
-  // built assets, the other Netlify functions, the Plausible proxy, and feeds.
+  // Run on every request, then exclude everything that isn't a meaningful page view:
+  // built assets, the other Netlify functions, the Plausible proxy, the IFTTT
+  // syndication feeds (polled constantly by automation), and the sitemap. The Atom
+  // feed (/feed.xml) is intentionally *not* excluded — it carries full article content,
+  // so agents fetching it is exactly the kind of traffic worth capturing.
   path: '/*',
   excludedPath: [
     '/javascripts/*',
@@ -83,8 +86,8 @@ export const config: Config = {
     '/og',
     '/robots.txt',
     '/plsbl/*',
+    '/ifttt/*',
     '/sitemap.xml',
-    '/feed.xml',
     '/.well-known/*',
     '/favicon.ico',
     '/*.png',
@@ -101,7 +104,6 @@ export const config: Config = {
     '/*.css',
     '/*.js',
     '/*.json',
-    '/*.xml',
     '/*.txt',
     '/*.map',
   ],


### PR DESCRIPTION
## What & why

Adds **Known Agents** analytics to the web app to track AI agents, crawlers, scrapers, and LLM-referral traffic.

Known Agents is the **rebrand of Dark Visitors** — the same company whose API this repo already uses to generate `robots.txt` — so it reuses the existing `DARK_VISITORS_ACCESS_TOKEN` (no new secret).

The site is static HTML on Netlify's CDN, and our existing Plausible analytics runs **client-side JavaScript**. Bots and AI crawlers — exactly what Known Agents measures — don't execute JS, so they're invisible to Plausible. The only place that runs on *every* request on a static Netlify site is a **Netlify Edge Function** (Deno), so that's where the tracking lives. This is additive and complementary: Plausible = humans-with-JS, Known Agents = bots/agents.

## How it works

`web/netlify/edge-functions/known-agents.ts`:

- Runs on `/*`, excluding built assets (`/javascripts/*`, `/stylesheets/*`, `/images/*`, `/fonts/*`, asset extensions), the other Netlify functions (`/api/*`, `/og`, `/robots.txt`), the Plausible proxy (`/plsbl/*`), and feeds — so only real page views are counted.
- Passes the static/CDN response through unchanged via `context.next()`.
- POSTs the visit to `https://api.knownagents.com/visits` in the **background** via `context.waitUntil`, so tracking adds **no latency** to the page (the documented equivalent of Cloudflare's `ctx.waitUntil`).
- **Production-only** (`CONTEXT === 'production'`) and fully **fail-open**: missing token, non-prod deploy, or any fetch error never breaks or delays a page render.
- Strips sensitive request headers (`cookie`, `authorization`) before sending; forwards `user-agent`, `referer`, and IP headers (`x-forwarded-for`) that Known Agents uses to classify agents.

Mirrors the existing `robots.mts` Dark Visitors pattern (hand-written `fetch`, token gating) rather than pulling in the Node-only `@knownagents/sdk`, which has no Deno/edge support.

## Setup

`DARK_VISITORS_ACCESS_TOKEN` is already set in Netlify and documented in `.env.example` / `web/CLAUDE.md` — no config changes needed. Tracking stays dormant until the token is present and the deploy is production.

## Verification

- [ ] Deploy preview renders pages normally (fail-open path: tracking is skipped on non-prod `CONTEXT`).
- [ ] After deploy to production, `curl -A "GPTBot" https://<site>/` produces a visit in the Known Agents realtime timeline, classified as an AI crawler.
- [ ] Requests to `/javascripts/site.js`, `/api/*`, `/og`, `/robots.txt` produce **no** visits.
- [ ] Plausible human pageviews still recorded; site headers/caching unchanged.

https://claude.ai/code/session_017jLo5o9ARzgAacsAhPST59

---
_Generated by [Claude Code](https://claude.ai/code/session_017jLo5o9ARzgAacsAhPST59)_