### PR TITLE
Fix Known Agents edge function never tracking in production

### DIFF
--- a/web/netlify/edge-functions/known-agents.ts
+++ b/web/netlify/edge-functions/known-agents.ts
@@ -50,11 +50,14 @@ async function trackVisit(
 }
 
 export default async function handler(request: Request, context: Context): Promise<Response> {
-  const token = Deno.env.get('DARK_VISITORS_ACCESS_TOKEN');
+  const token = Netlify.env.get('DARK_VISITORS_ACCESS_TOKEN');
 
   // Fail open: no token, or not a production deploy → pass straight through, untracked.
   // (Skipping previews/branch deploys keeps bot scans of those URLs out of the dataset.)
-  if (!token || Deno.env.get('CONTEXT') !== 'production') {
+  // Read the deploy context from the Context object: the CONTEXT env var is build-time
+  // only and is NOT present in the edge runtime, so reading it here always yields
+  // undefined and would skip tracking everywhere — including production.
+  if (!token || context.deploy.context !== 'production') {
     return context.next();
   }
 


### PR DESCRIPTION
## Problem

After #365 merged, **no visits were being tracked** in production.

## Root cause

The production gate read the deploy context from the wrong place:

```ts
if (!token || Deno.env.get('CONTEXT') !== 'production') {
  return context.next(); // pass through, untracked
}
```

`CONTEXT` is a Netlify **build-time** environment variable — it is **not** injected into the edge function's **runtime** environment. So at the edge `Deno.env.get('CONTEXT')` is always `undefined`, `undefined !== 'production'` is always `true`, and the function returned early **without tracking on every deploy context, including production**.

(Corroborating: `robots.mts` works because it only reads `DARK_VISITORS_ACCESS_TOKEN`/`URL` at runtime, never `CONTEXT`; the Ruby `is_production?` helper reads `ENV['CONTEXT']` but only at *build* time, where it exists.)

## Fix

Per Netlify's Edge Functions API docs, the runtime deploy context is exposed on the `Context` object as `context.deploy.context`. Gate on that instead, and read the token via the documented `Netlify.env.get` API:

```ts
const token = Netlify.env.get('DARK_VISITORS_ACCESS_TOKEN');
if (!token || context.deploy.context !== 'production') {
  return context.next();
}
```

No other behavior changes — `path`/`excludedPath`, the background `waitUntil` POST, header stripping, and `/feed.xml` inclusion are untouched.

## Verification

- [ ] Deploy preview still renders pages normally (stays untracked — its context is `deploy-preview`, exercising the fail-open path).
- [ ] After merge to production, `curl -A "GPTBot" https://<production-host>/` appears in the Known Agents realtime timeline within seconds, classified as an AI crawler.
- [ ] `/feed.xml` produces a visit; `/javascripts/site.js`, `/api/*`, `/og`, `/robots.txt`, `/sitemap.xml`, `/ifttt/*` produce none.

https://claude.ai/code/session_017jLo5o9ARzgAacsAhPST59

---
_Generated by [Claude Code](https://claude.ai/code/session_017jLo5o9ARzgAacsAhPST59)_