### PR TITLE
Fix Google Air Quality 400 and harden Upcoming Races widget

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       prism (~> 1.5)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -369,7 +369,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736

--- a/api/app/controllers/api/events_controller.rb
+++ b/api/app/controllers/api/events_controller.rb
@@ -52,19 +52,30 @@ module Api
       return if lat.blank? || lon.blank?
 
       gmaps = GoogleMaps.new(lat, lon)
-      time_zone = gmaps.time_zone_id || TimeZoneResolver.default
-      country = gmaps.country_code
+      time_zone = safely("GoogleMaps") { gmaps.time_zone_id } || TimeZoneResolver.default
+      country = safely("GoogleMaps") { gmaps.country_code }
 
       event_datetime = DateTime.parse(event.date).in_time_zone(time_zone)
       days_until = (event_datetime.to_date - Time.current.in_time_zone(time_zone).to_date).to_i
 
-      weather = WeatherKit.new(lat, lon, time_zone, country).data if country.present? && days_until.between?(0, 10)
-      aqi = GoogleAirQuality.new(lat, lon, country, "usa_epa_nowcast", event_datetime).aqi if country.present? && days_until.between?(0, 4)
-      goodspeed = Goodspeed.new.data
+      weather = safely("WeatherKit") { WeatherKit.new(lat, lon, time_zone, country).data } if country.present? && days_until.between?(0, 10)
+      aqi = safely("GoogleAirQuality") { GoogleAirQuality.new(lat, lon, country, "usa_epa_nowcast", event_datetime).aqi } if country.present? && days_until.between?(0, 4)
+      goodspeed = safely("Goodspeed") { Goodspeed.new.data }
 
-      record = DeepOstruct.wrap(sys: { id: event.sys&.id }, date: event.date, location: gmaps.location, location_label: event.location, aqi: aqi)
+      location = safely("GoogleMaps") { gmaps.location }
+      record = DeepOstruct.wrap(sys: { id: event.sys&.id }, date: event.date, location: location, location_label: event.location, aqi: aqi)
       record.weather = weather
       EventWeatherPresenter.new(record, goodspeed: goodspeed)
+    end
+
+    # Isolates a single upstream data source so one service raising doesn't collapse the whole
+    # widget. Reports the failure (matching the service layer's graceful-degradation contract)
+    # and falls back so the rest of the race-day card still renders.
+    def safely(service, fallback = nil)
+      yield
+    rescue StandardError => e
+      ErrorReporter.report_upstream(e, service: service, context: "#{self.class}#event_weather_for")
+      fallback
     end
   end
 end

--- a/api/app/services/google_air_quality.rb
+++ b/api/app/services/google_air_quality.rb
@@ -5,6 +5,10 @@ class GoogleAirQuality < ApplicationService
   attr_reader :aqi
   GOOGLE_AQI_API_URL = "https://airquality.googleapis.com/v1"
 
+  # Google's forecast endpoint only covers the next 96 hours (4 days); a dateTime beyond that
+  # returns 400 "The specified time period is not supported". Bail before requesting one.
+  FORECAST_MAX_HORIZON = 96.hours
+
   def initialize(latitude, longitude, country_code, aqi_code = "usa_epa_nowcast", datetime = nil)
     @latitude = latitude
     @longitude = longitude
@@ -51,6 +55,7 @@ class GoogleAirQuality < ApplicationService
   # @see https://developers.google.com/maps/documentation/air-quality/reference/rest/v1/forecast/lookup
   def get_forecast
     return if @latitude.blank? || @longitude.blank? || @country_code.blank? || @datetime.blank?
+    return if @datetime > Time.current + FORECAST_MAX_HORIZON
 
     cache_key = "google:aqi:forecast:#{@latitude}:#{@longitude}:#{@country_code}:#{@aqi_code}:#{@datetime.iso8601}"
     cached_json(cache_key, expires_in: 5.minutes) do

--- a/api/spec/requests/api/events_upcoming_spec.rb
+++ b/api/spec/requests/api/events_upcoming_spec.rb
@@ -310,6 +310,28 @@ RSpec.describe "Api::Events upcoming", type: :request do
     end
   end
 
+  context "when a single upstream data source fails" do
+    it "still renders the widget when the AQI service raises, just without AQI" do
+      allow(GoogleAirQuality).to receive(:new).and_raise(StandardError, "boom")
+
+      get "/api/events/upcoming", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Featured Race")
+      expect(response.body).to include("Race Day Weather") # weather still renders
+    end
+
+    it "still renders the widget when the bay-conditions service raises" do
+      allow_any_instance_of(Goodspeed).to receive(:data).and_raise(StandardError, "boom")
+
+      get "/api/events/upcoming", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Featured Race")
+      expect(response.body).to include("Race Day Weather")
+    end
+  end
+
   it "requires the API_TOKEN bearer (the proxy injects it; direct hits are rejected)" do
     get "/api/events/upcoming"
     expect(response).to have_http_status(:unauthorized)

--- a/api/spec/services/google_air_quality_spec.rb
+++ b/api/spec/services/google_air_quality_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe GoogleAirQuality do
+  let(:latitude) { 40.01 }
+  let(:longitude) { -105.27 }
+  let(:country) { "US" }
+
+  let(:aqi_index) do
+    {
+      code: "usa_epa_nowcast",
+      aqi: 42,
+      category: "Good air quality"
+    }
+  end
+
+  let(:current_body) { { indexes: [aqi_index] }.to_json }
+  let(:forecast_body) { { hourlyForecasts: [{ indexes: [aqi_index] }] }.to_json }
+
+  before do
+    # Cache always misses; writes are no-ops.
+    allow($redis).to receive(:get).and_return(nil)
+    allow($redis).to receive(:setex)
+
+    allow(HTTParty).to receive(:post) do |url, **_opts|
+      body = url.include?("forecast:lookup") ? forecast_body : current_body
+      instance_double(HTTParty::Response, success?: true, body: body, request: nil)
+    end
+  end
+
+  describe "current conditions" do
+    it "hits currentConditions:lookup when no datetime is given" do
+      result = described_class.new(latitude, longitude, country).aqi
+
+      expect(result).to eq(aqi: 42, category: "Good", description: "Good air quality")
+      expect(HTTParty).to have_received(:post).with(a_string_matching(%r{/currentConditions:lookup}), any_args)
+    end
+
+    it "hits currentConditions:lookup for a datetime in the past" do
+      described_class.new(latitude, longitude, country, "usa_epa_nowcast", 1.hour.ago)
+
+      expect(HTTParty).to have_received(:post).with(a_string_matching(%r{/currentConditions:lookup}), any_args)
+    end
+  end
+
+  describe "forecast" do
+    it "hits forecast:lookup for a datetime within the 96-hour horizon" do
+      result = described_class.new(latitude, longitude, country, "usa_epa_nowcast", 2.days.from_now).aqi
+
+      expect(result).to eq(aqi: 42, category: "Good", description: "Good air quality")
+      expect(HTTParty).to have_received(:post).with(a_string_matching(%r{/forecast:lookup}), any_args)
+    end
+
+    it "does not request a forecast beyond the 96-hour horizon (the 400 regression guard)" do
+      result = described_class.new(latitude, longitude, country, "usa_epa_nowcast", 5.days.from_now).aqi
+
+      expect(result).to be_nil
+      expect(HTTParty).not_to have_received(:post)
+    end
+  end
+
+  it "returns nil without any request when coordinates are blank" do
+    expect(described_class.new(nil, nil, country).aqi).to be_nil
+    expect(HTTParty).not_to have_received(:post)
+  end
+end


### PR DESCRIPTION
## What

Fixes the recurring `HTTP 400` from the Google Air Quality API and makes the Upcoming Races widget resilient to any single upstream failure.

## Why

Bugsnag was reporting a recurring `HTTP 400` raised from `ApplicationService#parse_json`, originating in `GoogleAirQuality#post_aqi` → `forecast:lookup`.

The request body itself is correct (verified against Google's `forecast.lookup` docs — `dateTime`, `customLocalAqis`, `extraComputations`, `languageCode` are all valid). The problem is the *value*: Google's forecast endpoint only covers the next **96 hours (4 days)**, returning `400 "The specified time period is not supported"` beyond that. `EventsController#event_weather_for` requested AQI whenever `days_until.between?(0, 4)`, and because `days_until` is a **calendar-day** difference, a "4 days out" event resolves to a timestamp up to ~120h ahead — past the horizon.

Separately, `event_weather_for` composes several independent upstreams (GoogleMaps, WeatherKit, GoogleAirQuality, Goodspeed). `GoogleMaps`/`GoogleAirQuality` don't wrap their HTTP calls, so a raise (timeout, parse error, …) could collapse the **entire** widget rather than just that field.

## Changes

- **`google_air_quality.rb`** — add `FORECAST_MAX_HORIZON = 96.hours` and skip the forecast request when `@datetime` is beyond it. No HTTP request is made for an out-of-range time; `aqi` simply returns `nil` (already a tolerated value).
- **`events_controller.rb`** — add a `safely(service) { … }` helper that reports any raise via `ErrorReporter.report_upstream` and falls back, then wrap each upstream call in `event_weather_for`. One failing source now blanks only its own field.
- **Tests** — new `spec/services/google_air_quality_spec.rb` (current vs. forecast routing; the beyond-96h guard makes no HTTP call) and a resilience context in `spec/requests/api/events_upcoming_spec.rb` (widget still renders when AQI / Goodspeed raises).

## Verification

- `rspec spec/services/google_air_quality_spec.rb spec/requests/api/events_upcoming_spec.rb` — green.
- Full suite: only the 5 pre-existing `plausible_pageviews_spec.rb` failures remain (present on the branch before this change, unrelated).
- `brakeman -q` — 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138FV2Y8urPHAAXzBKY5KRs

---
_Generated by [Claude Code](https://claude.ai/code/session_0138FV2Y8urPHAAXzBKY5KRs)_