### PR TITLE
Block fake-Google-referral bot at the edge

### DIFF
--- a/web/netlify/edge-functions/block-fake-google-bot.ts
+++ b/web/netlify/edge-functions/block-fake-google-bot.ts
@@ -1,0 +1,107 @@
+import type { Config, Context } from '@netlify/edge-functions';
+
+// Blocks a distributed bot that hammers article pages from a generic Linux desktop
+// Chrome user agent while faking a Google search referrer. The traffic comes from
+// hundreds of rotating IPs worldwide, so it can't be blocklisted by address — the
+// only reliable signature is the UA + referrer combination, which is rare for genuine
+// visitors. Returning a 403 (instead of the page) means the bot never receives the
+// HTML or the client-side Plausible script, so it stops polluting analytics and
+// skewing the trending-articles widget.
+
+// True when the UA looks like a plain Linux desktop Chrome browser (the shape the bot
+// sends: "Mozilla/5.0 (X11; Linux x86_64) … Chrome/… Safari/537.36"). Matches the
+// family rather than a specific Chrome version, so bumping the version doesn't evade it.
+// Excludes user agents that identify a different browser (Edge, Opera, Brave, Firefox)
+// or a self-identified bot/crawler — real Googlebot/Bingbot/etc. self-identify here and
+// don't send a www.google.com referrer anyway.
+function isLinuxChrome(userAgent: string): boolean {
+  const ua = userAgent.toLowerCase();
+  const looksLikeLinuxChrome =
+    ua.includes('x11; linux x86_64') &&
+    ua.includes('chrome/') &&
+    ua.includes('safari/537.36');
+  const looksLikeSomethingElse =
+    ua.includes('edg/') ||
+    ua.includes('opr/') ||
+    ua.includes('brave') ||
+    ua.includes('firefox') ||
+    ua.includes('headlesschrome') ||
+    ua.includes('bot') ||
+    ua.includes('spider') ||
+    ua.includes('crawl');
+  return looksLikeLinuxChrome && !looksLikeSomethingElse;
+}
+
+// True when the referrer's host is a Google domain. Host-based so query strings and
+// paths don't matter; a missing or malformed referrer parses as "not Google".
+function isGoogleReferrer(referer: string): boolean {
+  if (!referer) return false;
+  try {
+    const host = new URL(referer).hostname.toLowerCase();
+    return host === 'www.google.com' || host === 'google.com';
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(
+  request: Request,
+  context: Context
+): Promise<Response> {
+  const userAgent = request.headers.get('User-Agent') ?? '';
+  const referer = request.headers.get('Referer') ?? '';
+
+  if (isLinuxChrome(userAgent) && isGoogleReferrer(referer)) {
+    // no-store so the denial is never cached at the edge and can't leak onto a shared
+    // cache entry for this URL that would then be served to legitimate visitors.
+    return new Response('403 Forbidden — access denied.\n', {
+      status: 403,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+
+  // Not the bot: pass straight through to the page, unchanged.
+  return context.next();
+}
+
+export const config: Config = {
+  // If this function ever crashes, never block the page: bypass the error so the
+  // request chain continues and the downstream page/asset is returned unchanged.
+  onError: 'bypass',
+  // Run on every request, then exclude everything that isn't a meaningful page view —
+  // the bot targets article pages, which this covers. Mirrors known-agents.ts.
+  path: '/*',
+  excludedPath: [
+    '/javascripts/*',
+    '/stylesheets/*',
+    '/images/*',
+    '/fonts/*',
+    '/widgets/*',
+    '/og',
+    '/plsbl/*',
+    '/ifttt/*',
+    '/.well-known/*',
+    '/.netlify/images*',
+    '/favicon.ico',
+    '/*.png',
+    '/*.jpg',
+    '/*.jpeg',
+    '/*.gif',
+    '/*.svg',
+    '/*.webp',
+    '/*.avif',
+    '/*.ico',
+    '/*.woff',
+    '/*.woff2',
+    '/*.ttf',
+    '/*.css',
+    '/*.js',
+    '/*.json',
+    '/*.txt',
+    '/*.map',
+    '/*.xml',
+  ],
+};

--- a/web/netlify/edge-functions/block-fake-google-bot.ts
+++ b/web/netlify/edge-functions/block-fake-google-bot.ts
@@ -44,6 +44,31 @@ function isGoogleReferrer(referer: string): boolean {
   }
 }
 
+// One pipe-separated request log line: the given lead-in parts, then the requester's
+// referrer, user agent, IP, and geo (when known). Mirrors the format of the
+// known-agents edge function (web/netlify/edge-functions/known-agents.ts) so blocked
+// requests read the same way as the rest of the edge logs. context.ip is the
+// visitor's origin IP address.
+function requestLogLine(
+  request: Request,
+  context: Context,
+  ...parts: (string | null | undefined)[]
+): string {
+  const geo =
+    context.geo?.city && context.geo?.country?.name
+      ? `${context.geo.city}, ${context.geo.country.name}`
+      : context.geo?.city || context.geo?.country?.name;
+  return [
+    ...parts,
+    request.headers.get('Referer'),
+    request.headers.get('User-Agent'),
+    context.ip,
+    geo,
+  ]
+    .filter(Boolean)
+    .join(' | ');
+}
+
 export default async function handler(
   request: Request,
   context: Context
@@ -52,6 +77,15 @@ export default async function handler(
   const referer = request.headers.get('Referer') ?? '';
 
   if (isLinuxChrome(userAgent) && isGoogleReferrer(referer)) {
+    const url = new URL(request.url);
+    console.info(
+      requestLogLine(
+        request,
+        context,
+        `Blocked ${request.method} ${url.pathname}`,
+        '→ 403'
+      )
+    );
     // no-store so the denial is never cached at the edge and can't leak onto a shared
     // cache entry for this URL that would then be served to legitimate visitors.
     return new Response('403 Forbidden — access denied.\n', {


### PR DESCRIPTION
## What

Adds a new Netlify edge function, `web/netlify/edge-functions/block-fake-google-bot.ts`, that returns a `403` to the distributed bot currently flooding article pages.

## Why

The site is being hit by a bot making repeated requests to the same article pages from a generic Linux desktop Chrome user agent (`Mozilla/5.0 (X11; Linux x86_64) … Chrome/149.0.0.0 Safari/537.36`) carrying a faked `https://www.google.com/` referrer, spread across hundreds of rotating IPs worldwide. This pollutes Plausible analytics and skews the trending-articles widget (which is driven by Plausible pageviews).

Because the traffic rotates IPs, it can't be blocklisted by address — the reliable discriminator is the **user-agent + referrer** combination, which is rare for genuine visitors. Returning a `403` (instead of the page) means the bot never receives the HTML or the client-side Plausible script, so it immediately stops counting toward analytics and trending.

## How

The function blocks a request only when **both** hold:

- **User agent** looks like a plain Linux desktop Chrome browser — contains `X11; Linux x86_64`, `Chrome/`, and `Safari/537.36` — matched as a *family* (any Chrome version) so bumping the version doesn't evade it. User agents that self-identify as a different browser (Edge, Opera, Brave, Firefox) or a bot/crawler are excluded, so real Googlebot and legitimate Mac/Windows/Android Chrome traffic pass through.
- **Referrer** host is a Google domain (`www.google.com` / `google.com`), parsed host-based with a `try/catch` so a missing/malformed referrer is simply "not Google".

Everything else falls through to `context.next()` unchanged. The `403` sends `Cache-Control: no-store` so the denial is never cached at the edge for that URL. Config mirrors the existing `known-agents.ts` edge function (`path: '/*'` with the same asset `excludedPath` list, `onError: 'bypass'`).

No changes to `netlify.toml`, `package.json`, or any widget/placeholder markup.

## Testing

The two pure matcher functions were validated against real log samples (10 cases): the bot signature is blocked across Chrome versions, and every control case — real Mac/Windows/Android Chrome from Google, Googlebot, Linux Firefox, no-referrer, own-site referrer, `360Spider` — passes through. Suggested end-to-end check via `netlify dev` + `curl`:

```bash
# → 403
curl -sI -H 'Referer: https://www.google.com/' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36' \
  http://localhost:8888/2024/07/15/race-report-wild-15k/

# → 200 (real Mac Chrome from Google)
curl -sI -H 'Referer: https://www.google.com/' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36' \
  http://localhost:8888/2024/07/15/race-report-wild-15k/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNaC6XYjwnXHGheDScPjv4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNaC6XYjwnXHGheDScPjv4)_