### PR TITLE
Fix the Prettier check failure in web

### DIFF
--- a/web/source/javascripts/stimulus/controllers/publish_date_controller.js
+++ b/web/source/javascripts/stimulus/controllers/publish_date_controller.js
@@ -58,7 +58,7 @@ export default class extends Controller {
   }
 
   /**
-     * Shows a relative time that changes by itself for a recent article, or the absolute date from
+   * Shows a relative time that changes by itself for a recent article, or the absolute date from
    * the server for an older article. The relative time is a <wa-relative-time> element, which
    * updates itself. This code still renders each minute, thus the display changes to the absolute
    * date when the article is no longer from today.

--- a/web/test/browser/controllers/back_to_top.test.js
+++ b/web/test/browser/controllers/back_to_top.test.js
@@ -20,7 +20,7 @@ describe('back-to-top controller', () => {
     element.dispatchEvent(event);
 
     expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
-        // Without preventDefault, the browser also goes to #top, at the same time as the smooth
+    // Without preventDefault, the browser also goes to #top, at the same time as the smooth
     // scroll.
     expect(event.defaultPrevented).toBe(true);
   });

--- a/web/test/browser/controllers/clipboard.test.js
+++ b/web/test/browser/controllers/clipboard.test.js
@@ -94,7 +94,7 @@ describe('clipboard controller', () => {
   });
 
   it('cancels the pending revert when the element goes away', async () => {
-        // Without this code, a Turbo navigation during the countdown leaves a timer that changes a node
+    // Without this code, a Turbo navigation during the countdown leaves a timer that changes a node
     // that is not in the document. It is worse if the next page uses the same icons: the timer then
     // changes those icons.
     vi.useFakeTimers();

--- a/web/test/browser/registration.test.js
+++ b/web/test/browser/registration.test.js
@@ -45,7 +45,7 @@ const imports = new Map(
 
 describe('controller registration', () => {
   it('finds the controllers to check', () => {
-        // This checks the check: without it, a change to a name that broke the glob would make each
+    // This checks the check: without it, a change to a name that broke the glob would make each
     // test below pass with no content.
     expect(controllerFiles.length).toBeGreaterThan(0);
   });

--- a/web/test/plausible.test.ts
+++ b/web/test/plausible.test.ts
@@ -276,7 +276,7 @@ describe('handlePlausible', () => {
         makeCtx()
       );
 
-            // The code keeps these: the browser needs them to run the script and to cache it.
+      // The code keeps these: the browser needs them to run the script and to cache it.
       expect(res.headers.get('content-type')).toBe('application/javascript');
       expect(res.headers.get('cache-control')).toBe('public, max-age=3600');
       // The code removes these: each other header from the CDN of Plausible would go to the browser


### PR DESCRIPTION
## What

Runs `npm run format` in `web/`. It changes five lines, and each one is comment indentation.

## Why

`npm run format:check` fails on `main`. Five comment blocks kept too much indentation after
9646266e, the rewrite into Simplified Technical English. Thus each pull request that touches
`web/**` gets that failure, and #403 (the Dependabot satori bump) is the one that showed it.
That PR touches `web/package.json` and `web/package-lock.json` only, and it did not cause this.

## The change

| File | Line |
|---|---|
| `web/source/javascripts/stimulus/controllers/publish_date_controller.js` | 61 |
| `web/test/browser/controllers/back_to_top.test.js` | 23 |
| `web/test/browser/controllers/clipboard.test.js` | 97 |
| `web/test/browser/registration.test.js` | 48 |
| `web/test/plausible.test.ts` | 279 |

No code changes, and no change to `.prettierrc.json` or `.prettierignore`.

## Checks that ran locally (Node 24)

- `npm run format:check` — clean
- `npm run lint:js` — clean
- `npm run check` — clean
- `npm run test` — 276 tests in 23 files pass

## After the merge

The failed check on #403 does not run again by itself. Run that job again, or comment
`@dependabot rebase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gYuoSADLVMSMdsNCA7DCp