### PR TITLE
Keep satori below 0.33 and bundle the Worker in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,13 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    # ⚠️ satori 0.33 made `harfbuzzjs` a dependency of each render, and the Worker cannot run it:
+    # its Emscripten loader reads `fs` and `self.location`, and it compiles the wasm from bytes,
+    # which the runtime refuses. Thus the card renderer of web/ stays below 0.33. Remove this
+    # entry only after a render works in `wrangler dev`. Refer to web/CLAUDE.md.
+    ignore:
+      - dependency-name: "satori"
+        versions: [">=0.33.0"]
 
   # The local-only tools in utilities/. Nothing here goes to production, but all three have a
   # lockfile in the repo, and without this entry no CVE would ever change one. utilities/maps also

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -127,6 +127,17 @@ jobs:
       - name: Typecheck the Worker
         run: npm run check
 
+      # Bundle the Worker with wrangler, exactly as the deploy does. --dry-run needs no
+      # credentials and uploads nothing.
+      # ⚠️ This is the ONLY check that resolves the imports of `src/og-render.ts`. `npm test`
+      # cannot load that file (refer to web/CLAUDE.md), and `tsc` reads types and never bundles.
+      # Thus a dependency that the Worker cannot bundle passed each other check and stopped the
+      # deploy after the merge. That is the failure that this step stops.
+      # The script makes `build/` first, because wrangler reads `assets.directory` and this job
+      # does not build the site. The directory is in .gitignore.
+      - name: Bundle the Worker
+        run: npm run check:worker
+
       - name: RuboCop (style)
         run: bundle exec rubocop --no-color
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -286,9 +286,9 @@ The names only. Refer to `.env.example`, and never put a value in the repo.
 
 ## Conventions & gates
 
-**Before each commit** (these are necessary): `bundle exec rake test`, `npm test`, and
-`npm run check` pass. Then `bundle exec rubocop`, `npm run lint:js`, `npm run lint:scss`, and
-`npm run format:check` are clean. Then `bundle exec rake build:verbose` is successful. ⚠️ **`rake
+**Before each commit** (these are necessary): `bundle exec rake test`, `npm test`,
+`npm run check`, and `npm run check:worker` pass. Then `bundle exec rubocop`, `npm run lint:js`,
+`npm run lint:scss`, and `npm run format:check` are clean. Then `bundle exec rake build:verbose` is successful. ⚠️ **`rake
 build` does NOT run the tests**, and it is the one check that renders the templates: a bad partial
 passes each other check and then stops the deploy. ⚠️ Run it with the same environment as CI
 (`READING_TIME_WPM="" TIME_ZONE=""`). A GitHub Actions **variable** with no value arrives as an
@@ -306,10 +306,21 @@ only and needs no credentials.
 `@web.awesome.me/*`), `pagefind`, `wrangler`, and the two packages of the card renderer, `satori`
 and `@resvg/resvg-wasm`. Each test tool and each lint tool stays a `devDependency`.
 
-⚠️ **CI cannot check `satori` and `@resvg/resvg-wasm`.** No test in the suite does a render, and a
-new major version can change the wasm start contract or the text measurements of the card, and give
-no message. Render a card in `wrangler dev` (refer to **The two local loops**) and look at it before
-you merge a Dependabot PR.
+**`npm run check:worker`** bundles the Worker with `wrangler deploy --dry-run`. It needs no
+credentials, it uploads nothing, and it makes `build/` first, because wrangler reads
+`assets.directory`. It is the **only** check that resolves the imports of `src/og-render.ts`: no
+test can load that file, and `tsc` reads types and never bundles. The `checks` job of CI runs it.
+
+⚠️ **That check bundles the card renderer, and it does not RENDER a card.** `satori` and
+`@resvg/resvg-wasm` can bundle correctly and still change the wasm start contract or the text
+measurements of the card, and give no message. Render a card in `wrangler dev` (refer to **The two
+local loops**) and look at it before you merge a Dependabot PR.
+
+⚠️ **`satori` stays below 0.33**, and `.github/dependabot.yml` has an `ignore` entry that keeps it
+there. 0.33 made `harfbuzzjs` a dependency of each render, and the Worker cannot run that package:
+its Emscripten loader reads `fs` and `self.location`, and it compiles the wasm from bytes, which the
+runtime refuses. `nodejs_compat` and an alias make it bundle, but the render still stops at
+`self.location`. Remove the ignore entry only after a card renders in `wrangler dev`.
 
 **The markup of a widget**: an edit to a placeholder partial needs the same edit to the matching
 view in `api/` (refer to the root `CLAUDE.md`).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@web.awesome.me/webawesome-pro": "^3.12.0",
         "esbuild": "^0.28.2",
         "pagefind": "^1.5.2",
-        "satori": "^0.33.4",
+        "satori": "^0.32.0",
         "wrangler": "^4.126.0"
       },
       "devDependencies": {
@@ -4597,12 +4597,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/harfbuzzjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.10.0.tgz",
-      "integrity": "sha512-SN8LVwCOzvTq3OPNd0+EAghgXugItz56wst567D1vs7LnnKGWprhi3EG58aVOBwhN8HEbQxL4I9NDWkcXUutRw==",
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
@@ -6042,9 +6036,9 @@
       }
     },
     "node_modules/satori": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/satori/-/satori-0.33.4.tgz",
-      "integrity": "sha512-dCnaW6D/tkCJxG5UvpZPWnnvfTdGTVVSAq1tzH6xC5MeOhAeeswRcSq5zT7C6lRCdTGow9PRGus7PCzdp5JJYw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.32.0.tgz",
+      "integrity": "sha512-WwYeCWKjxfXvk7SsLSLTJhcPOrB2HCxbptqGIiYor0yqaPu3xA5uMTQ/4Dan5mxClhhk2Wn9ZE1pLGIlGdUxFQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@shuding/opentype.js": "1.4.0-beta.0",
@@ -6054,8 +6048,6 @@
         "css-to-react-native": "^3.0.0",
         "emoji-regex-xs": "^2.0.1",
         "escape-html": "^1.0.3",
-        "fflate": "0.7.3",
-        "harfbuzzjs": "0.10.0",
         "linebreak": "^1.1.0",
         "parse-css-color": "^0.2.1",
         "postcss-value-parser": "^4.2.0",
@@ -6064,12 +6056,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/satori/node_modules/fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==",
-      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --write \"**/*.{js,ts,mts,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,mts,json,md}\"",
     "check": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.test.json",
+    "check:worker": "mkdir -p build && wrangler deploy --dry-run",
     "test": "vitest run",
     "test:watch": "vitest",
     "pagefind": "pagefind --site build",
@@ -21,7 +22,7 @@
     "@web.awesome.me/webawesome-pro": "^3.12.0",
     "esbuild": "^0.28.2",
     "pagefind": "^1.5.2",
-    "satori": "^0.33.4",
+    "satori": "^0.32.0",
     "wrangler": "^4.126.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What broke

The `kona-web` deploy stopped right after #406 merged:

```
✘ [ERROR] Could not resolve "fs"
    node_modules/harfbuzzjs/hb.js:1:820:
      1 │ ...NMENT_IS_NODE){var fs=require("fs");scriptDirectory=__dirname+"/...
```

That Dependabot group bumped `satori` from 0.29.1 to **0.33.4**. satori 0.33.0 added
`harfbuzzjs` as a dependency, and `satori()` awaits its init on **every** render, so the Worker
bundle now pulls in an Emscripten loader that the runtime cannot run.

## Why not just add `nodejs_compat`

The error message suggests it, and it does make the bundle succeed — but the card then fails at
run time. Reproduced in `wrangler dev` against a copy of `web/src`:

| Attempt | Result |
|---|---|
| `nodejs_compat` | builds; render throws `TypeError: Cannot read properties of undefined (reading 'href')` at `self.location.href` in `hb.js` |
| `nodejs_compat` + `alias` for `harfbuzzjs` + `define` for `__filename` | builds; render throws `ReferenceError: __dirname is not defined` |
| `nodejs_compat` + alias + `define` for `__filename` **and** `__dirname` | works, renders a 25 KB PNG |

The working combination needs two **global** esbuild `define`s. Those apply to the whole bundle,
so any other library that detects Node with `typeof __dirname` would take its Node path. That is a
worse trade than staying one minor version back, so this PR pins instead.

## Changes

- **`web/package.json` / `package-lock.json`** — `satori` back to `^0.32.0`, the newest version
  with no `harfbuzzjs`. `harfbuzzjs` and its nested `fflate` drop out of the lockfile.
- **`.github/dependabot.yml`** — `ignore` `satori` at `>=0.33.0`, with the reason, so the group
  bump does not bring it back silently.
- **`.github/workflows/web.yml` + `web/package.json`** — new `npm run check:worker`
  (`mkdir -p build && wrangler deploy --dry-run`), run in the `checks` job. It needs no
  credentials and uploads nothing.
- **`web/CLAUDE.md`** — documents the new check, the pin, and that bundling still is not rendering.

## Why the new check

`checks` was green on #406 and the deploy failed anyway. Nothing in the suite resolves the imports
of `src/og-render.ts`: `npm test` cannot load that file (the pool's module loader sets the type for
`.wasm` only), and `tsc` reads types and never bundles. `wrangler deploy --dry-run` is the only
thing that runs the same esbuild pass as the deploy.

## Verification

Against a copy of `web/src` and the unchanged `wrangler.jsonc`:

- `wrangler deploy --dry-run` with satori 0.33.4 → **exit 1**, the same `Could not resolve "fs"`.
- `wrangler deploy --dry-run` with satori 0.32.0 → **exit 0**.
- `wrangler dev` with satori 0.32.0, calling `renderCard()` → 200, a 25,591-byte PNG.

The dry-run was checked with the credential env vars unset, and with an empty `build/`, which is
the state of the `checks` job.

⚠️ `npm ci` could not run in this session: `@web.awesome.me/webawesome-pro` needs the Cloudsmith
token, which is not available here. The verification above used a separate install of the Worker's
own dependencies (`satori`, `@resvg/resvg-wasm`, `wrangler`), which the browser bundle does not
touch. The full `checks` job on this PR covers the rest.

---
_Generated by [Claude Code](https://claude.ai/code/session_016EsfGRoohPvpvsNH9Ci8gV)_