### PR TITLE
Run Redis as an overmind process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dump.rdb
 .env
 .env.*
 !.env.example
+
+# The AOF of the dev Redis of `overmind start` (refer to Procfile.dev).
+/tmp/redis/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ its own test suite.
 Each app has its own Redis, through its own `REDIS_URL`: `api/` uses `kona-redis`, and `web/` uses a
 different Upstash instance. The two keyspaces are separate, and they share no data.
 
+⚠️ **Those two are PRODUCTION values, and a `.env` on your own machine must never hold one.** Use
+the local Redis that `overmind start` runs. The Upstash instance is a **metered** free tier of
+500,000 commands each month, and `overmind start` runs Sidekiq. An idle Sidekiq is not quiet: its
+fetch loop is a `BRPOP` with a 2-second timeout for each of its 5 threads, thus it makes
+approximately 2.5 commands each second, or 9,000 each hour, with no job at all. A development
+machine that points there uses the full month in approximately two days, and the graph shows
+`BRPOP` above each other command. Nothing gives you a message before the quota does.
+
 There is also a **Cloudflare R2 bucket** that holds a copy of each Contentful image asset. Its own
 custom domain in the zone serves it. There is no configuration for it in the repo: it is in the
 dashboard, and the api fills it. Refer to **The image mirror**.
@@ -53,7 +61,7 @@ There are two commands, and **the command that you run selects the API**. There 
 that, on purpose:
 
 ```bash
-overmind start                    # web :4567 + api :3000 + the api's esbuild watch, site → the local api
+overmind start                    # redis :6379 + web :4567 + api :3000 + the api's esbuild watch, site → the local api
 cd web && bundle exec middleman   # web only, site → the deployed api
 ```
 
@@ -64,18 +72,25 @@ is also why the plain `middleman` command still reaches production, from `web/.e
 `overmind restart web` restarts one process. `overmind connect api` gives a true TTY, thus
 `binding.break` works.
 
-⚠️ **Sidekiq starts with the other processes**: `overmind start` runs `web`, `api`, `js`, and
-`worker`. The worker was optional, because no widget endpoint adds a job to a queue. But the Course
-maps page of the admin changed that: a GPX file that a user uploads stays at "Processing" until
-`MapTilesetJob` publishes it. That page says so when it finds no Sidekiq process, but you must not
-need that message on your own machine.
+⚠️ **Sidekiq starts with the other processes**: `overmind start` runs `redis`, `web`, `api`, `js`,
+and `worker`. The worker was optional, because no widget endpoint adds a job to a queue. But the
+Course maps page of the admin changed that: a GPX file that a user uploads stays at "Processing"
+until `MapTilesetJob` publishes it. That page says so when it finds no Sidekiq process, but you must
+not need that message on your own machine.
+
+⚠️ **`redis` is a process of overmind, and not a service of brew and not a container.** It is first
+in `Procfile.dev`, because the api and the worker connect at their boot. It writes its AOF to
+`tmp/redis/`, which git ignores, thus the data of kona is its own. **Stop a Redis that already holds
+6379 before you start**, or that process cannot take the port and overmind stops. That failure is
+loud on purpose, thus `redis` is absent from `OVERMIND_CAN_DIE`.
 
 The `js` process is esbuild, which watches the admin bundle of the api. It applies to the admin
 pages of the api and to `/signin` only. The widgets and the site do not use it. ⚠️ Those pages raise
 `Propshaft::MissingAssetError` when nothing made the bundle. Thus run `npm run build` in `api/` one
 time after a new clone. `bin/setup` does that.
 
-The ports: 4567 for Middleman, 3000 for Rails, 8787 for `wrangler dev`, and 6379 for Redis. The api
+The ports: 4567 for Middleman, 3000 for Rails, 8787 for `wrangler dev`, and 6379 for the Redis of
+overmind. The api
 writes its log to `api/log/development.log`, and **not** to its overmind pane.
 
 Two conditions look like a problem and are not:

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -10,6 +10,15 @@
 ## context.watch() holds the event loop open by itself — web/'s external pipeline still needs
 ## esbuild's `--watch=forever` flag, because plain `--watch` exits when stdin closes and overmind
 ## spawns processes without one.
+## ⚠️ Redis is a process here, and not a service of brew and not a container. `overmind start` must
+## give the full stack, and this machine had no Redis of its own: the api and the site used the
+## container of a different project, which is up only when that project is up, and whose keyspace
+## they also shared. This process owns `tmp/redis/`, thus the data of kona is separate.
+## ⚠️ It is FIRST, because overmind starts each process in the order of this file and the api and
+## the worker connect at their boot.
+## ⚠️ Stop a Redis that already holds 6379 first, or this process cannot take the port. That failure
+## stops overmind, and it is loud on purpose: `redis` is absent from OVERMIND_CAN_DIE.
+redis:  redis-server --port 6379 --dir tmp/redis --save '' --appendonly yes --appendfsync everysec
 web:    cd web && bundle exec middleman
 api:    cd api && PORT=3000 bin/dev
 js:     cd api && npm run watch

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,6 +1,10 @@
 # Redis connection for the API's own cache (the `kona-redis` fly app in production; the web
 # app uses its own separate Upstash instance). Use rediss:// for TLS.
-REDIS_URL=
+# ⚠️ On your own machine, leave this at the local Redis that `overmind start` runs. NEVER point it
+# at the Upstash instance of web: that is a metered free tier, and `overmind start` also runs
+# Sidekiq, whose idle BRPOP fetch loop makes approximately 9,000 commands each hour with no job at
+# all. That uses a month of the quota in approximately two days, and nothing gives you a message.
+REDIS_URL=redis://localhost:6379
 
 # Size of the shared Redis connection pool (default 10). Sized to the widest consumer, which is
 # a web request fanning out to parallel upstreams — not Sidekiq's concurrency. Raise it if

--- a/web/.env.example
+++ b/web/.env.example
@@ -14,7 +14,10 @@ CONTENTFUL_TOKEN=
 URL=
 
 # Used for caching. Use rediss:// for TLS (e.g. Upstash).
-REDIS_URL=
+# ⚠️ Upstash is the PRODUCTION cache of this app, and the GitHub Actions build reads it from
+# secrets.REDIS_URL. On your own machine, use the local Redis that `overmind start` runs. Db 2 keeps
+# this build cache away from the api (db 0) and from the api specs (db 1).
+REDIS_URL=redis://localhost:6379/2
 
 # Base URL of the kona-api service. Used by the /widgets/* proxy and, at build time, to fetch
 # icons (POST /api/icons) and the standard.site verification data (GET /api/standard-site).


### PR DESCRIPTION
`overmind start` gave no Redis. The api and the site used the container of a different project, which is up only when that project is up, and whose keyspace they also shared. `redis` is now first in `Procfile.dev`, because the api and the worker connect at their boot, and it writes its AOF to `tmp/redis/`.